### PR TITLE
Reorder Primary Care services on homepage

### DIFF
--- a/templates/index.html
+++ b/templates/index.html
@@ -119,9 +119,9 @@
                 <img src="{{ url_for('static', filename='images/Primary Care Img.png') }}" alt="Primary Care Icon">
                 <h3>Primary Care</h3>
                 <ul>
+                    <li>Sick visits (ages 2+)</li>
                     <li>Annual physicals (ages 5+)</li>
                     <li>Chronic disease management (ages 8+)</li>
-                    <li>Sick visits (ages 2+)</li>
                 </ul>
             </div>
             <div class="service-card">


### PR DESCRIPTION
The list of services under the "Primary Care" section on the homepage has been reordered to display from youngest to oldest.

Old order:
- Annual physicals (ages 5+)
- Chronic disease management (ages 8+)
- Sick visits (ages 2+)

New order:
- Sick visits (ages 2+)
- Annual physicals (ages 5+)
- Chronic disease management (ages 8+)

This change was made by directly editing the hardcoded list in `templates/index.html`.