### PR TITLE
Add live Google reviews carousel to homepage

### DIFF
--- a/app.py
+++ b/app.py
@@ -1,21 +1,119 @@
-from flask import Flask, render_template, url_for, redirect
+from flask import Flask, render_template, url_for, redirect, jsonify
 import datetime
+import os
+import time
+
+import requests
 
 app = Flask(__name__)
 
 
 # Function to get the current year for the footer
+
 def get_current_year():
     return datetime.datetime.now().year
 
 
 # Register the function to be available in all templates
+
+
 @app.context_processor
 def inject_current_year():
-    return {'current_year': get_current_year()}
+    return {"current_year": get_current_year()}
+
+
+REVIEWS_CACHE = {"timestamp": 0, "payload": None}
+
+
+def get_reviews_cache_ttl():
+    """Return the cache TTL for Google review responses."""
+
+    try:
+        return int(os.getenv("GOOGLE_REVIEWS_CACHE_TTL", "3600"))
+    except ValueError:
+        return 3600
+
+
+def fetch_google_reviews(force_refresh: bool = False):
+    """Fetch five-star Google reviews for the configured place."""
+
+    api_key = os.getenv("GOOGLE_PLACES_API_KEY")
+    place_id = os.getenv("GOOGLE_PLACES_PLACE_ID")
+
+    if not api_key or not place_id:
+        raise RuntimeError(
+            "Google Places API configuration is missing. Set GOOGLE_PLACES_API_KEY and GOOGLE_PLACES_PLACE_ID."
+        )
+
+    cache_ttl = get_reviews_cache_ttl()
+    now = time.time()
+
+    if not force_refresh and REVIEWS_CACHE["payload"] is not None:
+        if now - REVIEWS_CACHE["timestamp"] < cache_ttl:
+            return REVIEWS_CACHE["payload"]
+
+    endpoint = "https://maps.googleapis.com/maps/api/place/details/json"
+    params = {
+        "place_id": place_id,
+        "fields": "rating,reviews,user_ratings_total",
+        "reviews_sort": "newest",
+        "language": "en",
+        "key": api_key,
+    }
+
+    try:
+        response = requests.get(endpoint, params=params, timeout=10)
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise RuntimeError("Unable to reach the Google Places API.") from exc
+
+    payload = response.json()
+    status = payload.get("status")
+    if status != "OK":
+        message = payload.get("error_message") or status or "Unknown error"
+        raise RuntimeError(f"Google Places API error: {message}")
+
+    result = payload.get("result", {})
+    raw_reviews = result.get("reviews", [])
+
+    five_star_reviews = []
+    for review in raw_reviews:
+        if review.get("rating") != 5:
+            continue
+
+        text = (review.get("text") or "").strip()
+        if not text:
+            continue
+
+        five_star_reviews.append(
+            {
+                "author_name": review.get("author_name"),
+                "author_url": review.get("author_url"),
+                "profile_photo_url": review.get("profile_photo_url"),
+                "rating": review.get("rating"),
+                "text": text,
+                "time": review.get("time"),
+                "relative_time_description": review.get("relative_time_description"),
+            }
+        )
+
+    five_star_reviews.sort(key=lambda item: item.get("time") or 0, reverse=True)
+
+    payload_summary = {
+        "reviews": five_star_reviews,
+        "rating": result.get("rating"),
+        "total_ratings": result.get("user_ratings_total"),
+        "fetched_at": datetime.datetime.utcnow().isoformat() + "Z",
+    }
+
+    REVIEWS_CACHE["payload"] = payload_summary
+    REVIEWS_CACHE["timestamp"] = now
+
+    return payload_summary
 
 
 # --- Page Routes ---
+
 
 @app.route('/')
 def index():
@@ -70,7 +168,36 @@ def summer_flyer_promo():
     return render_template('summer_flyer.html', page_title='Summer Flyer')
 
 
+@app.route('/api/google-reviews')
+def google_reviews():
+    try:
+        payload = fetch_google_reviews()
+    except RuntimeError as exc:
+        app.logger.warning("Google reviews unavailable: %s", exc)
+        return (
+            jsonify(
+                {
+                    "reviews": [],
+                    "error": "Google reviews are not available right now.",
+                }
+            ),
+            503,
+        )
+
+    reviews = payload.get("reviews", [])[:10]
+
+    return jsonify(
+        {
+            "reviews": reviews,
+            "rating": payload.get("rating"),
+            "total_ratings": payload.get("total_ratings"),
+            "fetched_at": payload.get("fetched_at"),
+        }
+    )
+
+
 if __name__ == '__main__':
     # Set debug=False when deploying to production (Heroku sets this via env var)
     # For local testing, you can use debug=True
     app.run(debug=False)  # Set debug=False for Heroku
+

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,2 +1,3 @@
 Flask>=2.0
 gunicorn>=20.0  # For Heroku deployment
+requests>=2.31

--- a/static/css/style.css
+++ b/static/css/style.css
@@ -561,3 +561,386 @@ body {
     opacity: 1;
     transform: translateY(0);
 }
+
+.is-hidden {
+    display: none !important;
+}
+
+/* --- Reviews Carousel --- */
+.reviews-section {
+    position: relative;
+    padding: 4em 0;
+    background: linear-gradient(180deg, rgba(55, 164, 219, 0.06) 0%, rgba(255, 255, 255, 0) 65%);
+}
+
+.reviews-header {
+    max-width: 720px;
+    margin: 0 auto 2.5em;
+    text-align: center;
+    display: flex;
+    flex-direction: column;
+    align-items: center;
+    gap: 1.2em;
+}
+
+.reviews-header h2 {
+    color: var(--accent-color);
+    margin-bottom: 0;
+}
+
+.reviews-subtitle {
+    color: #516072;
+    font-size: 1.05rem;
+    max-width: 540px;
+}
+
+.reviews-badge {
+    display: inline-flex;
+    align-items: center;
+    gap: 1em;
+    padding: 0.75em 1.25em;
+    border-radius: 999px;
+    background: rgba(55, 164, 219, 0.12);
+    box-shadow: inset 0 0 0 1px rgba(55, 164, 219, 0.2);
+}
+
+.reviews-badge__stars {
+    display: flex;
+    gap: 0.2em;
+    font-size: 1.3rem;
+    color: #f5b400;
+    letter-spacing: 0.1em;
+}
+
+.reviews-badge__star {
+    filter: drop-shadow(0 2px 6px rgba(245, 180, 0, 0.35));
+}
+
+.reviews-badge__details {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    line-height: 1.2;
+}
+
+.reviews-badge__rating {
+    font-family: var(--heading-font);
+    font-weight: 700;
+    font-size: 1.35rem;
+    color: var(--accent-color);
+}
+
+.reviews-badge__out-of {
+    font-size: 0.9rem;
+    color: #516072;
+    margin-left: 0.2em;
+}
+
+.reviews-badge__count {
+    font-size: 0.8rem;
+    text-transform: uppercase;
+    letter-spacing: 0.1em;
+    color: #516072;
+}
+
+.reviews-carousel {
+    display: grid;
+    grid-template-columns: auto 1fr auto;
+    align-items: center;
+    gap: 1.25em;
+    position: relative;
+}
+
+.reviews-window {
+    position: relative;
+    overflow: hidden;
+    border-radius: 22px;
+}
+
+.reviews-track {
+    display: flex;
+    transition: transform 0.6s cubic-bezier(0.22, 0.61, 0.36, 1);
+}
+
+.review-card {
+    background: #ffffff;
+    border-radius: 22px;
+    box-shadow: 0 20px 60px rgba(55, 164, 219, 0.16);
+    padding: 2.5em 2.5em 2em;
+    min-height: 260px;
+    flex: 0 0 100%;
+    display: flex;
+    flex-direction: column;
+    justify-content: space-between;
+    gap: 1.75em;
+    position: relative;
+}
+
+.review-card::after {
+    content: '';
+    position: absolute;
+    inset: 0;
+    border-radius: 22px;
+    pointer-events: none;
+    box-shadow: inset 0 0 0 1px rgba(55, 164, 219, 0.08);
+}
+
+.review-card__quote {
+    display: flex;
+    flex-direction: column;
+    gap: 1.2em;
+}
+
+.review-card__stars {
+    display: inline-flex;
+    gap: 0.3em;
+    color: #f5b400;
+}
+
+.review-card__star {
+    font-size: 1.1rem;
+    text-shadow: 0 4px 10px rgba(245, 180, 0, 0.3);
+}
+
+.review-card__star--empty {
+    color: #d9dde5;
+    text-shadow: none;
+}
+
+.review-card__text {
+    font-size: 1.1rem;
+    line-height: 1.7;
+    color: var(--accent-color);
+    margin: 0;
+    position: relative;
+}
+
+.review-card__text::before {
+    content: '“';
+    font-family: var(--heading-font);
+    font-size: 2.6rem;
+    line-height: 0.6;
+    color: rgba(55, 164, 219, 0.4);
+    position: absolute;
+    top: -1.2rem;
+    left: -0.6rem;
+}
+
+.review-card__footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1.5em;
+    flex-wrap: wrap;
+}
+
+.review-card__author {
+    display: flex;
+    align-items: center;
+    gap: 1em;
+}
+
+.review-card__avatar {
+    width: 48px;
+    height: 48px;
+    border-radius: 50%;
+    overflow: hidden;
+    background: linear-gradient(135deg, rgba(55, 164, 219, 0.25), rgba(55, 164, 219, 0.6));
+    display: flex;
+    align-items: center;
+    justify-content: center;
+    font-family: var(--heading-font);
+    font-weight: 600;
+    color: #fff;
+    letter-spacing: 0.05em;
+}
+
+.review-card__avatar img {
+    width: 100%;
+    height: 100%;
+    object-fit: cover;
+    display: block;
+}
+
+.review-card__author-meta {
+    display: flex;
+    flex-direction: column;
+    gap: 0.2em;
+}
+
+.review-card__name {
+    font-weight: 600;
+    color: var(--accent-color);
+}
+
+.review-card__name a {
+    color: inherit;
+    text-decoration: none;
+}
+
+.review-card__name a:hover {
+    text-decoration: underline;
+}
+
+.review-card__date {
+    font-size: 0.9rem;
+    color: #6a7b8f;
+}
+
+.review-card__source {
+    display: inline-flex;
+    align-items: center;
+    gap: 0.4em;
+    font-size: 0.9rem;
+    color: #6a7b8f;
+}
+
+.review-card__source svg {
+    width: 1rem;
+    height: 1rem;
+}
+
+.review-card--loading,
+.review-card--fallback {
+    align-items: center;
+    justify-content: center;
+    text-align: center;
+    gap: 1em;
+}
+
+.review-card__spinner {
+    width: 2.5rem;
+    height: 2.5rem;
+    border-radius: 50%;
+    border: 3px solid rgba(55, 164, 219, 0.2);
+    border-top-color: var(--primary-color);
+    animation: review-spinner 1s linear infinite;
+}
+
+.review-card__message {
+    font-size: 1rem;
+    color: #6a7b8f;
+    margin: 0;
+}
+
+.reviews-status {
+    margin-top: 1.5em;
+    text-align: center;
+    color: #6a7b8f;
+    font-size: 0.95rem;
+}
+
+.carousel-control {
+    width: 3.25rem;
+    height: 3.25rem;
+    border-radius: 50%;
+    border: none;
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    background: #ffffff;
+    box-shadow: 0 10px 30px rgba(55, 164, 219, 0.25);
+    color: var(--primary-color);
+    cursor: pointer;
+    transition: transform 0.3s ease, box-shadow 0.3s ease, background-color 0.3s ease, color 0.3s ease;
+}
+
+.carousel-control svg {
+    width: 1.2rem;
+    height: 1.2rem;
+    fill: currentColor;
+}
+
+.carousel-control:hover {
+    transform: translateY(-2px);
+    background: var(--primary-color);
+    color: #ffffff;
+    box-shadow: 0 16px 36px rgba(55, 164, 219, 0.28);
+}
+
+.carousel-control:disabled {
+    opacity: 0.4;
+    cursor: not-allowed;
+    box-shadow: none;
+}
+
+.carousel-control:focus-visible {
+    outline: 3px solid rgba(55, 164, 219, 0.35);
+    outline-offset: 3px;
+}
+
+@keyframes review-spinner {
+    to {
+        transform: rotate(360deg);
+    }
+}
+
+@media (max-width: 992px) {
+    .reviews-section {
+        padding: 3.5em 0;
+    }
+
+    .reviews-carousel {
+        gap: 0.75em;
+    }
+
+    .carousel-control {
+        width: 3rem;
+        height: 3rem;
+    }
+}
+
+@media (max-width: 768px) {
+    .reviews-carousel {
+        grid-template-columns: 1fr;
+        padding: 0 2.5em;
+    }
+
+    .carousel-control {
+        position: absolute;
+        top: 50%;
+        transform: translateY(-50%);
+        z-index: 2;
+    }
+
+    .carousel-control--prev {
+        left: 0.5em;
+    }
+
+    .carousel-control--next {
+        right: 0.5em;
+    }
+}
+
+@media (max-width: 600px) {
+    .reviews-section {
+        padding: 3em 0;
+    }
+
+    .reviews-header {
+        margin-bottom: 2em;
+    }
+
+    .review-card {
+        padding: 2.2em 1.8em 1.8em;
+        min-height: 0;
+    }
+
+    .reviews-carousel {
+        padding: 0 1.5em;
+    }
+
+    .carousel-control {
+        width: 2.6rem;
+        height: 2.6rem;
+    }
+
+    .reviews-badge {
+        gap: 0.6em;
+        padding: 0.6em 1em;
+    }
+
+    .reviews-badge__rating {
+        font-size: 1.15rem;
+    }
+}

--- a/static/js/script.js
+++ b/static/js/script.js
@@ -56,4 +56,336 @@ document.addEventListener('DOMContentLoaded', () => {
         revealObserver.observe(el);
     });
 
+    // --- Google Reviews Carousel ---
+    const reviewsSection = document.querySelector('[data-reviews-section]');
+    if (reviewsSection) {
+        const carousel = reviewsSection.querySelector('[data-reviews-carousel]');
+        const track = reviewsSection.querySelector('[data-reviews-track]');
+        const viewport = reviewsSection.querySelector('[data-reviews-window]');
+        const prevButton = reviewsSection.querySelector('[data-reviews-prev]');
+        const nextButton = reviewsSection.querySelector('[data-reviews-next]');
+        const status = reviewsSection.querySelector('[data-reviews-status]');
+        let loaderCard = reviewsSection.querySelector('[data-reviews-loader]');
+        const summary = reviewsSection.querySelector('[data-reviews-summary]');
+        const ratingValue = reviewsSection.querySelector('[data-reviews-rating]');
+        const countValue = reviewsSection.querySelector('[data-reviews-count]');
+
+        let reviews = [];
+        let currentIndex = 0;
+        let autoPlayTimer = null;
+
+        const AUTO_PLAY_INTERVAL = 8000;
+
+        const setStatus = (message) => {
+            if (!status) {
+                return;
+            }
+            if (message) {
+                status.textContent = message;
+                status.classList.remove('is-hidden');
+            } else {
+                status.textContent = '';
+                status.classList.add('is-hidden');
+            }
+        };
+
+        const removeLoader = () => {
+            if (loaderCard && loaderCard.parentElement) {
+                loaderCard.parentElement.removeChild(loaderCard);
+            }
+            loaderCard = null;
+        };
+
+        const formatTimestamp = (timestamp) => {
+            if (!timestamp) {
+                return 'Recent review';
+            }
+            try {
+                return new Intl.DateTimeFormat(undefined, {
+                    year: 'numeric',
+                    month: 'short',
+                }).format(new Date(timestamp * 1000));
+            } catch (error) {
+                return 'Recent review';
+            }
+        };
+
+        const createStarContainer = (rating = 5) => {
+            const wrapper = document.createElement('div');
+            wrapper.className = 'review-card__stars';
+            const normalizedRating = Math.round(Number(rating) || 5);
+            wrapper.setAttribute('aria-label', `${normalizedRating} out of 5 stars`);
+
+            for (let index = 0; index < 5; index += 1) {
+                const star = document.createElement('span');
+                star.className = 'review-card__star';
+                if (index >= normalizedRating) {
+                    star.classList.add('review-card__star--empty');
+                    star.textContent = '☆';
+                } else {
+                    star.textContent = '★';
+                }
+                wrapper.appendChild(star);
+            }
+
+            return wrapper;
+        };
+
+        const createReviewCard = (review) => {
+            const card = document.createElement('article');
+            card.className = 'review-card';
+
+            const quote = document.createElement('div');
+            quote.className = 'review-card__quote';
+            quote.appendChild(createStarContainer(review.rating));
+
+            const text = document.createElement('p');
+            text.className = 'review-card__text';
+            const reviewText = typeof review.text === 'string' ? review.text.trim() : '';
+            text.textContent = reviewText;
+            quote.appendChild(text);
+
+            const footer = document.createElement('div');
+            footer.className = 'review-card__footer';
+
+            const author = document.createElement('div');
+            author.className = 'review-card__author';
+
+            const avatar = document.createElement('div');
+            avatar.className = 'review-card__avatar';
+            const rawAuthorName = typeof review.author_name === 'string' ? review.author_name.trim() : '';
+            const authorName = rawAuthorName || 'Google user';
+            if (review.profile_photo_url) {
+                const img = document.createElement('img');
+                img.src = review.profile_photo_url;
+                img.alt = `${authorName}'s Google profile photo`;
+                avatar.appendChild(img);
+            } else {
+                const initial = authorName.charAt(0) || 'G';
+                avatar.textContent = initial.toUpperCase();
+            }
+
+            const meta = document.createElement('div');
+            meta.className = 'review-card__author-meta';
+
+            const name = document.createElement('span');
+            name.className = 'review-card__name';
+            if (review.author_url) {
+                const link = document.createElement('a');
+                link.href = review.author_url;
+                link.target = '_blank';
+                link.rel = 'noopener noreferrer';
+                link.textContent = authorName;
+                name.appendChild(link);
+            } else {
+                name.textContent = authorName;
+            }
+
+            const date = document.createElement('span');
+            date.className = 'review-card__date';
+            date.textContent = review.relative_time_description || formatTimestamp(review.time);
+
+            meta.appendChild(name);
+            meta.appendChild(date);
+
+            author.appendChild(avatar);
+            author.appendChild(meta);
+
+            const source = document.createElement('span');
+            source.className = 'review-card__source';
+            source.innerHTML = `
+                <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                    <path fill="#EA4335" d="M12 11.8v3.6h5.1c-.2 1.3-1.5 3.8-5.1 3.8-3.1 0-5.6-2.6-5.6-5.8s2.5-5.8 5.6-5.8c1.8 0 3.1.8 3.8 1.5l2.6-2.5C16.7 5 14.6 4 12 4 6.9 4 2.8 8.1 2.8 13.2S6.9 22.4 12 22.4c6.5 0 8.9-4.6 8.9-7.8 0-.5-.1-1-.1-1.4H12z"></path>
+                    <path fill="#34A853" d="M3.3 7.7l3 2.2C7.6 7.5 9.6 6.1 12 6.1c1.8 0 3.1.8 3.8 1.5l2.6-2.5C16.7 3.7 14.6 2.7 12 2.7 8.4 2.7 5.3 4.7 3.3 7.7z"></path>
+                    <path fill="#FBBC05" d="M12 22.4c3.6 0 6.1-1.2 7.8-3l-3.6-2.7c-1 .7-2.4 1.2-4.2 1.2-3.3 0-6-2.4-6.6-5.6l-3.1 2.4c1.7 3.5 5 5.7 9.7 5.7z"></path>
+                    <path fill="#4285F4" d="M20.9 14.6c-.2-1.1-.6-2-1-2.8H12v3.6h5.1c-.1.8-.6 1.9-1.6 2.6l3.6 2.7c1-1.1 1.7-2.6 1.7-4.1 0-.7-.1-1.3-.3-2z"></path>
+                </svg>
+                <span>Google Reviews</span>
+            `;
+
+            footer.appendChild(author);
+            footer.appendChild(source);
+
+            card.appendChild(quote);
+            card.appendChild(footer);
+
+            return card;
+        };
+
+        const showFallbackCard = (message) => {
+            if (!track) {
+                return;
+            }
+            track.innerHTML = '';
+            const card = document.createElement('article');
+            card.className = 'review-card review-card--fallback';
+            const messageElement = document.createElement('p');
+            messageElement.className = 'review-card__message';
+            messageElement.textContent = message;
+            card.appendChild(messageElement);
+            track.appendChild(card);
+        };
+
+        const updateTransform = () => {
+            if (!viewport || !track) {
+                return;
+            }
+            const width = viewport.getBoundingClientRect().width;
+            track.style.transform = `translateX(-${width * currentIndex}px)`;
+        };
+
+        const goTo = (index) => {
+            if (!reviews.length) {
+                return;
+            }
+            const total = reviews.length;
+            currentIndex = (index + total) % total;
+            updateTransform();
+        };
+
+        const updateControls = () => {
+            const shouldDisable = reviews.length <= 1;
+            if (prevButton) {
+                prevButton.disabled = shouldDisable;
+            }
+            if (nextButton) {
+                nextButton.disabled = shouldDisable;
+            }
+        };
+
+        const stopAutoPlay = () => {
+            if (autoPlayTimer) {
+                window.clearInterval(autoPlayTimer);
+                autoPlayTimer = null;
+            }
+        };
+
+        const startAutoPlay = () => {
+            stopAutoPlay();
+            if (reviews.length <= 1) {
+                return;
+            }
+            autoPlayTimer = window.setInterval(() => {
+                goTo(currentIndex + 1);
+            }, AUTO_PLAY_INTERVAL);
+        };
+
+        const renderReviews = (items) => {
+            reviews = items;
+            track.innerHTML = '';
+
+            const fragment = document.createDocumentFragment();
+            reviews.forEach((review) => {
+                fragment.appendChild(createReviewCard(review));
+            });
+
+            track.appendChild(fragment);
+            currentIndex = 0;
+            updateTransform();
+            updateControls();
+            startAutoPlay();
+        };
+
+        const applySummary = (data) => {
+            if (!summary || !ratingValue) {
+                return;
+            }
+
+            const rating = Number(data.rating);
+            if (Number.isFinite(rating)) {
+                ratingValue.textContent = rating.toFixed(1);
+                summary.classList.remove('is-hidden');
+            }
+
+            if (countValue && data.total_ratings !== undefined && data.total_ratings !== null) {
+                const total = Number(data.total_ratings);
+                if (Number.isFinite(total)) {
+                    countValue.textContent = total.toLocaleString();
+                }
+            }
+        };
+
+        const handleSuccess = (data) => {
+            removeLoader();
+
+            const fetchedReviews = Array.isArray(data.reviews)
+                ? data.reviews.filter(
+                      (item) => item && typeof item.text === 'string' && item.text.trim()
+                  )
+                : [];
+
+            if (!fetchedReviews.length) {
+                showFallbackCard('Google reviews are not available right now. Please check back soon.');
+                setStatus('Google reviews are not available right now.');
+                return;
+            }
+
+            renderReviews(fetchedReviews);
+            applySummary(data);
+            setStatus('');
+        };
+
+        const handleError = (message) => {
+            removeLoader();
+            showFallbackCard(message);
+            setStatus(message);
+            if (summary) {
+                summary.classList.add('is-hidden');
+            }
+            stopAutoPlay();
+        };
+
+        if (prevButton) {
+            prevButton.addEventListener('click', () => {
+                if (!reviews.length) {
+                    return;
+                }
+                stopAutoPlay();
+                goTo(currentIndex - 1);
+                startAutoPlay();
+            });
+        }
+
+        if (nextButton) {
+            nextButton.addEventListener('click', () => {
+                if (!reviews.length) {
+                    return;
+                }
+                stopAutoPlay();
+                goTo(currentIndex + 1);
+                startAutoPlay();
+            });
+        }
+
+        if (carousel) {
+            carousel.addEventListener('mouseenter', stopAutoPlay);
+            carousel.addEventListener('mouseleave', startAutoPlay);
+            carousel.addEventListener('focusin', stopAutoPlay);
+            carousel.addEventListener('focusout', startAutoPlay);
+        }
+
+        window.addEventListener('resize', updateTransform);
+
+        fetch('/api/google-reviews')
+            .then(async (response) => {
+                const data = await response
+                    .json()
+                    .catch(() => ({ reviews: [], error: 'Unable to load Google reviews.' }));
+
+                if (!response.ok) {
+                    const message = data.error || 'Unable to load Google reviews at this time.';
+                    throw new Error(message);
+                }
+
+                return data;
+            })
+            .then((data) => {
+                handleSuccess(data);
+            })
+            .catch((error) => {
+                console.error('Failed to fetch Google reviews', error);
+                handleError(error.message || 'Unable to load Google reviews at this time.');
+            });
+    }
+
 });

--- a/templates/index.html
+++ b/templates/index.html
@@ -153,6 +153,49 @@
     </div>
 </section>
 
+<section class="reviews-section reveal" aria-labelledby="google-reviews-title" data-reviews-section>
+    <div class="container">
+        <div class="reviews-header">
+            <div class="reviews-badge is-hidden" data-reviews-summary>
+                <div class="reviews-badge__stars" aria-hidden="true">
+                    <span class="reviews-badge__star">★</span>
+                    <span class="reviews-badge__star">★</span>
+                    <span class="reviews-badge__star">★</span>
+                    <span class="reviews-badge__star">★</span>
+                    <span class="reviews-badge__star">★</span>
+                </div>
+                <div class="reviews-badge__details">
+                    <span class="reviews-badge__rating"><span data-reviews-rating>—</span><span class="reviews-badge__out-of">/5</span></span>
+                    <span class="reviews-badge__count"><span data-reviews-count>—</span> Google reviews</span>
+                </div>
+            </div>
+            <h2 id="google-reviews-title">Loved by Patients Across Chattanooga</h2>
+            <p class="reviews-subtitle">Real 5-star stories pulled directly from our Google Reviews listing.</p>
+        </div>
+        <div class="reviews-carousel" data-reviews-carousel>
+            <button class="carousel-control carousel-control--prev" type="button" aria-label="Show previous review" data-reviews-prev>
+                <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                    <path d="M15.5 19a1 1 0 0 1-.7-.29l-6-6a1 1 0 0 1 0-1.42l6-6a1 1 0 0 1 1.41 1.42L10.91 12l5.3 5.29A1 1 0 0 1 15.5 19z" />
+                </svg>
+            </button>
+            <div class="reviews-window" data-reviews-window>
+                <div class="reviews-track" data-reviews-track>
+                    <article class="review-card review-card--loading" data-reviews-loader>
+                        <div class="review-card__spinner" aria-hidden="true"></div>
+                        <p>Loading Google reviews…</p>
+                    </article>
+                </div>
+            </div>
+            <button class="carousel-control carousel-control--next" type="button" aria-label="Show next review" data-reviews-next>
+                <svg viewBox="0 0 24 24" aria-hidden="true" focusable="false">
+                    <path d="M8.5 19a1 1 0 0 1-.71-1.71L13.09 12l-5.3-5.29a1 1 0 1 1 1.41-1.42l6 6a1 1 0 0 1 0 1.42l-6 6A1 1 0 0 1 8.5 19z" />
+                </svg>
+            </button>
+        </div>
+        <p class="reviews-status" data-reviews-status aria-live="polite">Fetching the latest Google feedback…</p>
+    </div>
+</section>
+
 {# Add more sections as needed - e.g., Testimonials, Meet the Team Snippet #}
 
 {% endblock %}


### PR DESCRIPTION
## Summary
- add a cached Google Places API integration that serves five-star reviews via a new `/api/google-reviews` endpoint
- style and markup a homepage section for the Google reviews carousel and surface the location rating badge
- build JavaScript to fetch reviews, render the carousel, and provide autoplay/controls with graceful fallbacks

## Testing
- python -m compileall .

------
https://chatgpt.com/codex/tasks/task_e_68cadebf787c832abe8e2c2a46991604