### PR TITLE
Add Owner-only quarterly bonus report

### DIFF
--- a/app.py
+++ b/app.py
@@ -366,6 +366,18 @@ def create_app():
             app.logger.error(f"Error generating RVU chart: {e}")
             return "Error generating chart", 500
 
+    @app.route('/admin/reports/bonus')
+    @login_required
+    def bonus_report():
+        if current_user.role != 'Owner':
+            return jsonify({'error': 'Forbidden'}), 403
+        try:
+            data = rvu_analytics.get_quarterly_bonus_report()
+            return jsonify(data)
+        except Exception as e:
+            app.logger.error(f"Error generating bonus report: {e}")
+            return jsonify({'error': 'Failed to generate report'}), 500
+
     @app.route('/admin/logout')
     @login_required
     def admin_logout():

--- a/data/rvu_analytics.py
+++ b/data/rvu_analytics.py
@@ -4,6 +4,7 @@ matplotlib.use('Agg')
 import matplotlib.pyplot as plt
 import io
 import re
+from datetime import date
 
 try:
     from . import data_loader
@@ -193,6 +194,114 @@ def generate_rvu_chart(view_type):
     plt.close(fig)
     img_buffer.seek(0)
     return img_buffer.getvalue()
+
+def calculate_bonus(rvus):
+    """Calculate quarterly bonus for a given RVU total.
+
+    Tiers:
+      $25 per RVU over 689 (up to 735)
+      $30 per RVU over 735 (up to 827)
+      $35 per RVU over 827
+    """
+    if rvus <= 689:
+        return 0.0
+    bonus = 0.0
+    # Tier 1: 690–735 at $25/RVU
+    tier1 = min(rvus, 735) - 689
+    bonus += tier1 * 25
+    # Tier 2: 736–827 at $30/RVU
+    if rvus > 735:
+        tier2 = min(rvus, 827) - 735
+        bonus += tier2 * 30
+    # Tier 3: 828+ at $35/RVU
+    if rvus > 827:
+        tier3 = rvus - 827
+        bonus += tier3 * 35
+    return bonus
+
+
+def get_quarterly_bonus_report(today=None):
+    """Return per-provider bonus data for the current calendar quarter.
+
+    Returns a dict with 'quarter_label', 'days_elapsed', 'days_in_quarter',
+    and 'providers' (list of per-provider dicts).
+    """
+    if today is None:
+        today = date.today()
+
+    # Determine current quarter boundaries
+    q = (today.month - 1) // 3
+    quarter_start = date(today.year, q * 3 + 1, 1)
+    if q < 3:
+        quarter_end = date(today.year, (q + 1) * 3 + 1, 1)
+    else:
+        quarter_end = date(today.year + 1, 1, 1)
+
+    days_elapsed = (today - quarter_start).days + 1  # inclusive of today
+    days_in_quarter = (quarter_end - quarter_start).days
+    quarter_label = f"Q{q + 1} {today.year}"
+
+    # Load RVU dataset and filter to current quarter
+    df = get_rvu_dataset()
+    if df.empty:
+        return {
+            'quarter_label': quarter_label,
+            'days_elapsed': days_elapsed,
+            'days_in_quarter': days_in_quarter,
+            'providers': [],
+        }
+
+    mask = (
+        (df['Date Of Service'] >= pd.Timestamp(quarter_start))
+        & (df['Date Of Service'] < pd.Timestamp(quarter_end))
+    )
+    qdf = df[mask]
+
+    # Include the Anne Jenks manual 216-RVU adjustment, prorated to this quarter
+    # (get_rvu_dataset spreads it across ALL weeks since 2025-10-01, so we
+    #  compute the per-quarter share based on weeks in this quarter vs total)
+    all_weeks = df['Week'].unique()
+    quarter_weeks = qdf['Week'].unique()
+    if len(all_weeks) > 0 and len(quarter_weeks) > 0:
+        adjustment_this_quarter = 216.0 * len(quarter_weeks) / len(all_weeks)
+    else:
+        adjustment_this_quarter = 0.0
+
+    # Sum RVUs per provider (from raw data, without the chart adjustment)
+    provider_rvus = qdf.groupby('Provider')['RVU'].sum()
+
+    providers = []
+    for prov in data_loader.VALID_PROVIDERS:
+        rvus_earned = float(provider_rvus.get(prov, 0.0))
+
+        # Add Anne Jenks manual adjustment
+        if prov == 'ANNE JENKS':
+            rvus_earned += adjustment_this_quarter
+
+        bonus_earned = calculate_bonus(rvus_earned)
+
+        # Extrapolate to full quarter
+        if days_elapsed > 0:
+            projected_rvus = rvus_earned * days_in_quarter / days_elapsed
+        else:
+            projected_rvus = 0.0
+        projected_bonus = calculate_bonus(projected_rvus)
+
+        providers.append({
+            'provider': prov.title(),
+            'rvus_earned': round(rvus_earned, 1),
+            'bonus_earned': round(bonus_earned, 2),
+            'projected_rvus': round(projected_rvus, 1),
+            'projected_bonus': round(projected_bonus, 2),
+        })
+
+    return {
+        'quarter_label': quarter_label,
+        'days_elapsed': days_elapsed,
+        'days_in_quarter': days_in_quarter,
+        'providers': providers,
+    }
+
 
 def _generate_error_chart(message):
     fig, ax = plt.subplots(figsize=(8, 4))

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -369,6 +369,32 @@
                 </div>
                 {% endif %}
             </div>
+
+            {% if current_user.role == 'Owner' %}
+            <div class="admin-panel" style="margin-top: 2rem;">
+                <h2>💰 Quarterly Bonus Report</h2>
+                <p id="bonus-quarter-info" style="color: var(--text-light); font-size: 0.95rem; margin-bottom: 1.5rem;">
+                    Loading...
+                </p>
+
+                <div style="overflow-x: auto;">
+                    <table id="bonus-table" style="width: 100%; border-collapse: collapse; font-size: 0.95rem;">
+                        <thead>
+                            <tr style="background: #f1f5f9; text-align: left;">
+                                <th style="padding: 0.75rem 1rem; border-bottom: 2px solid #e2e8f0;">Provider</th>
+                                <th style="padding: 0.75rem 1rem; border-bottom: 2px solid #e2e8f0; text-align: right;">RVUs Earned</th>
+                                <th style="padding: 0.75rem 1rem; border-bottom: 2px solid #e2e8f0; text-align: right;">Bonus Earned</th>
+                                <th style="padding: 0.75rem 1rem; border-bottom: 2px solid #e2e8f0; text-align: right;">Projected RVUs</th>
+                                <th style="padding: 0.75rem 1rem; border-bottom: 2px solid #e2e8f0; text-align: right;">Projected Bonus</th>
+                            </tr>
+                        </thead>
+                        <tbody id="bonus-tbody">
+                            <tr><td colspan="5" style="padding: 2rem; text-align: center; color: var(--text-light);">Loading...</td></tr>
+                        </tbody>
+                    </table>
+                </div>
+            </div>
+            {% endif %}
         </div>
 
         <!-- Conditional Banner Management -->
@@ -559,6 +585,41 @@
         });
 
         resetTimers();
+
+        // --- Bonus Report (Owner only) ---
+        (function loadBonusReport() {
+            const tbody = document.getElementById('bonus-tbody');
+            const info = document.getElementById('bonus-quarter-info');
+            if (!tbody) return; // not Owner
+
+            fetch("{{ url_for('bonus_report') }}")
+                .then(r => r.json())
+                .then(data => {
+                    if (data.error) { tbody.innerHTML = '<tr><td colspan="5" style="padding:1rem;text-align:center;color:#ef4444;">Error loading report.</td></tr>'; return; }
+
+                    const pct = Math.round(data.days_elapsed / data.days_in_quarter * 100);
+                    info.textContent = data.quarter_label + ' — Day ' + data.days_elapsed + ' of ' + data.days_in_quarter + ' (' + pct + '% complete)';
+
+                    const fmt = n => '$' + n.toLocaleString('en-US', {minimumFractionDigits: 0, maximumFractionDigits: 0});
+
+                    let rows = '';
+                    data.providers.forEach(p => {
+                        const earnedColor = p.bonus_earned > 0 ? '#16a34a' : 'inherit';
+                        const projColor = p.projected_bonus > 0 ? '#16a34a' : 'inherit';
+                        rows += '<tr style="border-bottom:1px solid #e5e7eb;">'
+                            + '<td style="padding:0.75rem 1rem;font-weight:500;">' + p.provider + '</td>'
+                            + '<td style="padding:0.75rem 1rem;text-align:right;">' + p.rvus_earned.toFixed(1) + '</td>'
+                            + '<td style="padding:0.75rem 1rem;text-align:right;color:' + earnedColor + ';font-weight:600;">' + fmt(p.bonus_earned) + '</td>'
+                            + '<td style="padding:0.75rem 1rem;text-align:right;color:var(--text-light);font-style:italic;">' + p.projected_rvus.toFixed(1) + '</td>'
+                            + '<td style="padding:0.75rem 1rem;text-align:right;color:' + projColor + ';font-style:italic;">' + fmt(p.projected_bonus) + '</td>'
+                            + '</tr>';
+                    });
+                    tbody.innerHTML = rows;
+                })
+                .catch(() => {
+                    tbody.innerHTML = '<tr><td colspan="5" style="padding:1rem;text-align:center;color:#ef4444;">Failed to load bonus report.</td></tr>';
+                });
+        })();
     </script>
 </body>
 


### PR DESCRIPTION
## Summary
- Add tiered quarterly bonus calculation: $25/RVU over 689, $30/RVU over 735, $35/RVU over 827
- Add `GET /admin/reports/bonus` endpoint (Owner role only, 403 for others)
- Add bonus report table to admin dashboard Reports tab, visible only to Owners
- Shows per-provider: RVUs earned, bonus earned, projected RVUs, projected bonus
- Dynamically determines current quarter with progress indicator (e.g., "Q1 2026 — Day 85 of 90")

## Test plan
- [x] Bonus math verified against 14 reference values from the provided table
- [x] All 16 existing data module tests pass
- [ ] Log in as Owner → bonus report table visible in Reports tab
- [ ] Log in as Admin/Provider → bonus section not visible
- [ ] Hit `/admin/reports/bonus` as non-Owner → 403 response

🤖 Generated with [Claude Code](https://claude.com/claude-code)