### PR TITLE
Add Owner Analytics dashboard with scorecards, trends, breakeven, and…

### DIFF
--- a/app.py
+++ b/app.py
@@ -370,6 +370,31 @@ def create_app():
             app.logger.error(f"Error generating RVU chart: {e}")
             return "Error generating chart", 500
 
+    @app.route('/admin/api/pull-data', methods=['POST'])
+    @login_required
+    def admin_pull_data():
+        """
+        Trigger the automated data ingestion pipeline (Owner only).
+        Returns JSON so the admin UI can display live feedback.
+        """
+        if current_user.role != 'Owner':
+            return jsonify({'error': 'Only Owners can trigger data ingestion.'}), 403
+
+        source = request.json.get('source', 'all') if request.is_json else 'all'
+        sources = None
+        if source == 'va':
+            sources = ['va']
+        elif source == 'pc':
+            sources = ['pc']
+
+        try:
+            from data.data_ingestion import run_ingestion_pipeline
+            results = run_ingestion_pipeline(sources=sources)
+            return jsonify({'status': 'ok', 'results': results})
+        except Exception as exc:
+            app.logger.error(f"Data ingestion error: {exc}")
+            return jsonify({'status': 'error', 'error': str(exc)}), 500
+
     @app.route('/admin/reports/owner_analytics')
     @login_required
     def owner_analytics_data():
@@ -434,6 +459,50 @@ def create_app():
 
 # --- Application entry-point ---
 app = create_app()
+
+
+# --- CLI commands ---
+
+import click
+
+
+@app.cli.command("pull-data")
+@click.option(
+    "--source",
+    default="all",
+    type=click.Choice(["all", "va", "pc"], case_sensitive=False),
+    help="Data source to pull: 'va' (Google Sheets), 'pc' (Tebra), or 'all'.",
+)
+def pull_data_command(source):
+    """Pull RVU source data from external APIs and store in the database.
+
+    VA data is pulled from Google Sheets (requires GOOGLE_SHEETS_CREDENTIALS).
+    Primary Care data is pulled from the Tebra/Kareo SOAP API (requires TEBRAKEY).
+    """
+    from data.data_ingestion import run_ingestion_pipeline
+
+    sources = None  # defaults to ['va', 'pc']
+    if source == "va":
+        sources = ["va"]
+    elif source == "pc":
+        sources = ["pc"]
+
+    click.echo(f"Starting data ingestion (source={source})...")
+    results = run_ingestion_pipeline(sources=sources)
+
+    any_error = False
+    for src, result in results.items():
+        if result["status"] == "ok":
+            click.echo(f"  OK  {src.upper()}: {result['rows']} rows ingested")
+        else:
+            click.echo(f"  ERR {src.upper()}: {result['error']}", err=True)
+            any_error = True
+
+    if any_error:
+        raise SystemExit(1)
+
+    click.echo("Done.")
+
 
 if __name__ == '__main__':
     app.run(debug=False)

--- a/app.py
+++ b/app.py
@@ -11,6 +11,7 @@ import requests
 from models import db, User, BannerSettings, ReferenceData
 from datetime import timezone
 from data import rvu_analytics
+from data import owner_analytics
 
 def create_app():
     app = Flask(__name__)
@@ -368,6 +369,18 @@ def create_app():
         except Exception as e:
             app.logger.error(f"Error generating RVU chart: {e}")
             return "Error generating chart", 500
+
+    @app.route('/admin/reports/owner_analytics')
+    @login_required
+    def owner_analytics_data():
+        if current_user.role != 'Owner':
+            return jsonify({'error': 'Owner access required'}), 403
+        try:
+            data = owner_analytics.get_all_analytics()
+            return jsonify(data)
+        except Exception as e:
+            app.logger.error(f"Error generating owner analytics: {e}")
+            return jsonify({'error': 'Failed to generate analytics data'}), 500
 
     @app.route('/admin/logout')
     @login_required

--- a/data/data_ingestion.py
+++ b/data/data_ingestion.py
@@ -1,0 +1,656 @@
+"""
+Data ingestion module for automated pulling of:
+  1. VA C&P Exam data from Google Sheets
+  2. Primary Care charges from Tebra/Kareo SOAP API
+
+The pipeline stores clean data in the ReferenceData table using the same
+filenames ('201 Bills and Payments.csv', 'Charges Export.csv') that
+data_loader.py already reads — so the dashboard immediately picks up fresh
+data without any other code changes.
+
+Usage (Flask CLI):
+    flask pull-data              # pull both sources
+    flask pull-data --source va  # pull VA only
+    flask pull-data --source pc  # pull primary care only
+
+Environment variables required:
+    GOOGLE_SHEETS_CREDENTIALS  — JSON string for a GCP service account
+    TEBRAKEY                   — Tebra/Kareo customer API key
+    TEBRA_USER                 — (optional) Tebra username
+    TEBRA_PASSWORD             — (optional) Tebra password
+    DATABASE_URL               — PostgreSQL URL (falls back to local SQLite)
+"""
+
+import datetime
+import io
+import json
+import logging
+import os
+import re
+import xml.etree.ElementTree as ET
+
+import pandas as pd
+import requests
+
+logger = logging.getLogger(__name__)
+
+# ── Constants ─────────────────────────────────────────────────────────────────
+
+TEBRA_SOAP_URL = "https://webservice.kareo.com/services/soap/2.1/"
+SHEETS_SPREADSHEET_ID = "195fdZnKs1SrWd9EqV9CRXF3kt6a71mFtXWPNu6bpCLM"
+
+# PII fields that must be stripped from Tebra data immediately after retrieval.
+# This list is intentionally broad — any field name containing patient/guarantor
+# demographics must not survive past _strip_pii_from_charge().
+TEBRA_PII_FIELDS = {
+    "PatientFirstName", "PatientLastName", "PatientFullName", "PatientName",
+    "PatientDOB", "PatientDateOfBirth", "PatientSSN", "PatientSocialSecurity",
+    "PatientAddress", "PatientAddress1", "PatientAddress2",
+    "PatientCity", "PatientState", "PatientZip", "PatientZipCode",
+    "PatientPhone", "PatientPhoneNumber", "PatientCellPhone",
+    "PatientEmail", "PatientEmailAddress",
+    "GuarantorFirstName", "GuarantorLastName", "GuarantorAddress",
+    "GuarantorPhone", "GuarantorEmail",
+    "PatientChartNumber", "PatientAccountNumber",
+}
+
+# The only fields we want to keep from a Tebra charge record.
+TEBRA_SAFE_FIELDS = {
+    "ServiceDate",
+    "ProcedureCode",
+    "Modifiers",
+    "RenderingProviderName",
+    "FacilityName",
+    "ChargeAmount",
+    "Units",
+    "PrimaryInsuranceName",
+    "SecondaryInsuranceName",
+    "InsuranceContractAdjustment",
+    "InsurancePaymentAmount",
+    "PatientPaymentAmount",
+    "OtherAdjustment",
+}
+
+# CPT code → Work RVU lookup table.
+# Values sourced from CMS Physician Fee Schedule (2024).
+# Descriptions are kept as inline comments for maintainability.
+CPT_RVU_MAP: dict[str, float] = {
+    # Office/outpatient E&M — established patient
+    "99211": 0.18,  "99212": 0.70,  "99213": 1.30,  "99214": 1.92,  "99215": 2.80,
+    # Office/outpatient E&M — new patient
+    "99202": 0.93,  "99203": 1.42,  "99204": 2.43,  "99205": 3.17,
+    # Annual wellness visits
+    "G0438": 1.50,  "G0439": 1.30,
+    "99385": 1.75,  "99386": 1.92,  "99387": 2.00,
+    "99395": 1.50,  "99396": 1.75,  "99397": 1.92,
+    # Telehealth (audio-only E&M)
+    "99441": 0.48,  "99442": 0.97,  "99443": 1.50,
+    # Prolonged services
+    "99354": 1.76,  "99355": 1.76,  "99417": 0.61,
+    # Vaccine administration
+    "90471": 0.17,  "90472": 0.15,  "90473": 0.17,  "90474": 0.15,
+    # Common vaccines (administration component only)
+    "90686": 0.17,  "90714": 0.17,  "90718": 0.17,  "90707": 0.17,
+    # DOT / occupational physicals
+    "99455": 1.77,  "99456": 1.77,
+    # Medical opinion / nexus letter (miscellaneous service)
+    "99080": 2.50,
+    # Complex chronic care management
+    "99487": 1.00,  "99489": 0.50,  "99490": 0.61,  "99491": 1.05,
+    # Transitional care management
+    "99495": 2.11,  "99496": 3.13,
+}
+
+# ── Google Sheets ─────────────────────────────────────────────────────────────
+
+def _get_sheets_service():
+    """
+    Build and return an authenticated Google Sheets API service object.
+
+    Reads service account credentials from the GOOGLE_SHEETS_CREDENTIALS
+    environment variable (JSON string).
+
+    Raises:
+        RuntimeError: If required Google API libraries are not installed.
+        ValueError:   If GOOGLE_SHEETS_CREDENTIALS is not set.
+    """
+    try:
+        from google.oauth2 import service_account
+        from googleapiclient.discovery import build
+    except ImportError as exc:
+        raise RuntimeError(
+            "Google API libraries not installed. "
+            "Run: pip install google-api-python-client google-auth"
+        ) from exc
+
+    creds_json = os.environ.get("GOOGLE_SHEETS_CREDENTIALS")
+    if not creds_json:
+        raise ValueError("GOOGLE_SHEETS_CREDENTIALS environment variable not set")
+
+    creds_dict = json.loads(creds_json)
+    scopes = ["https://www.googleapis.com/auth/spreadsheets.readonly"]
+    credentials = service_account.Credentials.from_service_account_info(
+        creds_dict, scopes=scopes
+    )
+    return build("sheets", "v4", credentials=credentials, cache_discovery=False)
+
+
+def pull_google_sheets_va_data(spreadsheet_id: str = SHEETS_SPREADSHEET_ID) -> bytes:
+    """
+    Pull VA C&P exam data from a Google Sheets spreadsheet.
+
+    Returns the sheet contents as UTF-8 CSV bytes whose columns match the
+    '201 Bills and Payments.csv' schema that data_loader.load_va_data() expects.
+
+    Args:
+        spreadsheet_id: Google Sheets document ID.
+
+    Returns:
+        CSV bytes ready to be stored in the ReferenceData table.
+
+    Raises:
+        ValueError: If the sheet is empty.
+        RuntimeError: If the Google API call fails.
+    """
+    logger.info("Pulling VA data from Google Sheets (id=%s)", spreadsheet_id)
+
+    service = _get_sheets_service()
+
+    try:
+        result = (
+            service.spreadsheets()
+            .values()
+            .get(spreadsheetId=spreadsheet_id, range="A:Z")
+            .execute()
+        )
+    except Exception as exc:
+        raise RuntimeError(f"Google Sheets API call failed: {exc}") from exc
+
+    values = result.get("values", [])
+    if not values:
+        raise ValueError("Google Sheets returned empty data")
+
+    headers = values[0]
+    rows = values[1:]
+
+    # Pad short rows to header length so DataFrame construction doesn't fail
+    rows = [r + [""] * (len(headers) - len(r)) for r in rows]
+    df = pd.DataFrame(rows, columns=headers)
+
+    # Drop completely blank rows
+    df = df[df.apply(lambda r: r.str.strip().ne("").any(), axis=1)].reset_index(drop=True)
+
+    if df.empty:
+        raise ValueError("Google Sheets returned no data rows")
+
+    logger.info("Pulled %d VA rows from Google Sheets", len(df))
+    return df.to_csv(index=False).encode("utf-8")
+
+
+# ── Tebra / Kareo SOAP API ────────────────────────────────────────────────────
+
+def _build_get_charges_request(
+    api_key: str,
+    from_date: str,
+    to_date: str,
+    username: str = "",
+    password: str = "",
+) -> str:
+    """
+    Construct the SOAP XML envelope for a GetCharges request.
+
+    Args:
+        api_key:   Tebra customer API key (TEBRAKEY).
+        from_date: Start date as 'YYYY-MM-DD'.
+        to_date:   End date as 'YYYY-MM-DD'.
+        username:  Optional Tebra username.
+        password:  Optional Tebra password.
+
+    Returns:
+        SOAP XML string (UTF-8).
+    """
+    # Escape XML special characters in credentials
+    def _esc(s: str) -> str:
+        return (
+            s.replace("&", "&amp;")
+             .replace("<", "&lt;")
+             .replace(">", "&gt;")
+             .replace('"', "&quot;")
+             .replace("'", "&apos;")
+        )
+
+    return (
+        '<?xml version="1.0" encoding="utf-8"?>'
+        '<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/"'
+        ' xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"'
+        ' xmlns:xsd="http://www.w3.org/2001/XMLSchema">'
+        "<soap:Body>"
+        '<GetCharges xmlns="http://www.kareo.com/api/schemas/">'
+        "<request>"
+        "<RequestHeader>"
+        f"<CustomerKey>{_esc(api_key)}</CustomerKey>"
+        f"<User>{_esc(username)}</User>"
+        f"<Password>{_esc(password)}</Password>"
+        "</RequestHeader>"
+        f"<FromServiceDate>{from_date}</FromServiceDate>"
+        f"<ToServiceDate>{to_date}</ToServiceDate>"
+        "</request>"
+        "</GetCharges>"
+        "</soap:Body>"
+        "</soap:Envelope>"
+    )
+
+
+def _strip_pii_from_charge(charge_dict: dict) -> dict:
+    """
+    Remove all PII fields from a charge record dictionary.
+
+    Only fields present in TEBRA_SAFE_FIELDS are retained.  Any field not
+    explicitly listed as safe is dropped, even if it is not in the known PII
+    list — this is a whitelist approach for maximum safety.
+
+    Args:
+        charge_dict: Raw charge record as a flat dict.
+
+    Returns:
+        New dict containing only safe, non-PII fields.
+    """
+    return {k: v for k, v in charge_dict.items() if k in TEBRA_SAFE_FIELDS}
+
+
+def _parse_charges_response(xml_text: str) -> list[dict]:
+    """
+    Parse a Tebra GetCharges SOAP response and return PII-stripped records.
+
+    PII is stripped immediately upon parsing each element — raw patient data
+    never exists as a complete dict in memory after this function runs.
+
+    Args:
+        xml_text: Raw SOAP response body as a string.
+
+    Returns:
+        List of clean charge dicts (PII removed).
+
+    Raises:
+        ValueError: If the XML cannot be parsed.
+    """
+    try:
+        root = ET.fromstring(xml_text)
+    except ET.ParseError as exc:
+        raise ValueError(f"Failed to parse Tebra SOAP response: {exc}") from exc
+
+    _ns = re.compile(r"\{[^}]+\}")
+
+    def _tag(el) -> str:
+        return _ns.sub("", el.tag)
+
+    charges = []
+    for el in root.iter():
+        if _tag(el) in ("Charge", "ChargeDTO"):
+            raw: dict = {}
+            for child in el:
+                raw[_tag(child)] = (child.text or "").strip()
+            # Strip PII immediately — never accumulate patient demographics
+            charges.append(_strip_pii_from_charge(raw))
+
+    return charges
+
+
+def _normalize_tebra_charges(charges: list[dict]) -> pd.DataFrame:
+    """
+    Convert stripped Tebra charge dicts into a DataFrame whose columns match
+    the 'Charges Export.csv' schema that data_loader.load_pc_data() expects.
+
+    Args:
+        charges: List of PII-free charge dicts from _parse_charges_response().
+
+    Returns:
+        DataFrame with standardised column names.
+    """
+    df = pd.DataFrame(charges) if charges else pd.DataFrame()
+
+    column_map = {
+        "ServiceDate":                   "Date Of Service",
+        "RenderingProviderName":         "Rendering Provider",
+        "ProcedureCode":                 "Procedure Codes with Modifiers",
+        "Modifiers":                     "Modifiers",
+        "ChargeAmount":                  "Service Charge Amount",
+        "Units":                         "Units",
+        "FacilityName":                  "Facility Name",
+        "PrimaryInsuranceName":          "Pri Ins Name",
+        "SecondaryInsuranceName":        "Sec Ins Name",
+        "InsuranceContractAdjustment":   "Pri Ins Insurance Contract Adjustment",
+        "InsurancePaymentAmount":        "Pri Ins Insurance Payment",
+        "PatientPaymentAmount":          "Pat Payment Amount",
+        "OtherAdjustment":              "Other Adjustment",
+    }
+    df = df.rename(columns={k: v for k, v in column_map.items() if k in df.columns})
+
+    # Guarantee the columns load_pc_data() requires exist
+    required = [
+        "Date Of Service",
+        "Rendering Provider",
+        "Procedure Codes with Modifiers",
+        "Service Charge Amount",
+        "Units",
+    ]
+    for col in required:
+        if col not in df.columns:
+            df[col] = ""
+
+    return df
+
+
+def pull_tebra_charges(
+    from_date: str | None = None,
+    to_date: str | None = None,
+    timeout: int = 60,
+) -> bytes:
+    """
+    Pull charges from the Tebra/Kareo SOAP API with immediate PII stripping.
+
+    Returns CSV bytes compatible with the 'Charges Export.csv' format.
+
+    Args:
+        from_date: Start date as 'YYYY-MM-DD'. Defaults to 90 days ago.
+        to_date:   End date as 'YYYY-MM-DD'. Defaults to today.
+        timeout:   HTTP request timeout in seconds.
+
+    Returns:
+        CSV bytes ready to be stored in the ReferenceData table.
+
+    Raises:
+        ValueError:  If TEBRAKEY is not set.
+        RuntimeError: If the HTTP request fails.
+    """
+    api_key = os.environ.get("TEBRAKEY")
+    if not api_key:
+        raise ValueError("TEBRAKEY environment variable not set")
+
+    username = os.environ.get("TEBRA_USER", "")
+    password = os.environ.get("TEBRA_PASSWORD", "")
+
+    if not from_date:
+        from_date = (datetime.datetime.today() - datetime.timedelta(days=90)).strftime("%Y-%m-%d")
+    if not to_date:
+        to_date = datetime.datetime.today().strftime("%Y-%m-%d")
+
+    logger.info("Pulling Tebra charges from %s to %s", from_date, to_date)
+
+    soap_body = _build_get_charges_request(api_key, from_date, to_date, username, password)
+    headers = {
+        "Content-Type": "text/xml; charset=utf-8",
+        "SOAPAction": "http://www.kareo.com/api/schemas/GetCharges",
+    }
+
+    try:
+        response = requests.post(
+            TEBRA_SOAP_URL,
+            data=soap_body.encode("utf-8"),
+            headers=headers,
+            timeout=timeout,
+        )
+        response.raise_for_status()
+    except requests.RequestException as exc:
+        raise RuntimeError(f"Tebra API request failed: {exc}") from exc
+
+    charges = _parse_charges_response(response.text)
+
+    if not charges:
+        logger.warning("Tebra API returned 0 charges for the requested date range")
+        empty = pd.DataFrame(
+            columns=["Date Of Service", "Rendering Provider",
+                     "Procedure Codes with Modifiers", "Service Charge Amount", "Units"]
+        )
+        return empty.to_csv(index=False).encode("utf-8")
+
+    df = _normalize_tebra_charges(charges)
+    logger.info("Pulled and sanitised %d charge records from Tebra", len(df))
+    return df.to_csv(index=False).encode("utf-8")
+
+
+# ── CPT → RVU mapping ────────────────────────────────────────────────────────
+
+def cpt_to_rvu(cpt_code: str, procedure_description: str = "") -> float:
+    """
+    Map a CPT code to a Work RVU value.
+
+    Lookup order:
+      1. Exact match in CPT_RVU_MAP
+      2. Regex pattern matching for E&M and vaccine ranges
+      3. Description-based keyword fallback (mirrors rvu_analytics logic)
+
+    Args:
+        cpt_code:              CPT code string (e.g. '99213').
+        procedure_description: Optional free-text description for fallback.
+
+    Returns:
+        RVU value as float. Returns 0.0 if the code is unknown.
+    """
+    clean = re.sub(r"\s+", "", str(cpt_code)).upper()
+
+    # 1. Exact lookup
+    if clean in CPT_RVU_MAP:
+        return CPT_RVU_MAP[clean]
+
+    # 2. Pattern ranges
+    if re.search(r"992[01][1-5]", clean):   # 99211-99215 / 99201-99205
+        return 1.30
+    if re.search(r"993[89][0-9]", clean):   # 99381-99397 annual/preventive
+        return 1.30
+    if re.search(r"90[4-7][0-9]{2}", clean):  # 904xx-907xx vaccine admin
+        return 0.50
+
+    # 3. Description fallback
+    desc = procedure_description.upper()
+    if "FUNCTIONAL" in desc and "INITIAL" in desc:
+        return 3.75
+    if "FUNCTIONAL" in desc:
+        return 2.50
+    if "NEXUS" in desc:
+        return 2.50
+    if "DOT" in desc and "PHYSICAL" in desc:
+        return 1.0
+    if "ANNUAL" in desc or "PHYSICAL" in desc:
+        return 1.30
+    if "VACCINE" in desc or "ADMIN" in desc:
+        return 0.50
+
+    return 0.0
+
+
+# ── Deduplication ────────────────────────────────────────────────────────────
+
+#: Column subset used to decide whether two PC charge rows are the same charge.
+#: Patient-identifying columns (name, chart #) are intentionally excluded —
+#: deduplication relies solely on clinical and billing fields.
+PC_DEDUP_KEYS = [
+    "Date Of Service",
+    "Rendering Provider",
+    "Procedure Codes with Modifiers",
+    "Service Charge Amount",
+    "Units",
+]
+
+
+def _read_existing_csv_from_db(filename: str) -> pd.DataFrame:
+    """
+    Load an existing CSV blob from the ReferenceData table.
+
+    Returns an empty DataFrame if the file is not found or the table doesn't
+    exist yet (e.g., fresh deployment with no uploaded data).
+    """
+    from sqlalchemy import create_engine, text
+
+    database_url = os.environ.get("DATABASE_URL", "")
+    if not database_url:
+        base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        db_path = os.path.join(base_dir, "instance", "site.db")
+        database_url = f"sqlite:///{db_path}"
+
+    if database_url.startswith("postgres://"):
+        database_url = database_url.replace("postgres://", "postgresql://", 1)
+
+    try:
+        engine = create_engine(database_url)
+        with engine.connect() as conn:
+            row = conn.execute(
+                text("SELECT data FROM reference_data WHERE filename = :f"),
+                {"f": filename},
+            ).fetchone()
+            if row and row[0]:
+                return pd.read_csv(io.BytesIO(bytes(row[0])))
+    except Exception as exc:
+        logger.warning("Could not load existing '%s' from DB: %s", filename, exc)
+    return pd.DataFrame()
+
+
+def _dedup_charges(new_df: pd.DataFrame, existing_df: pd.DataFrame) -> pd.DataFrame:
+    """
+    Merge freshly pulled charges with the existing dataset and remove duplicates.
+
+    Deduplication key: PC_DEDUP_KEYS (date, provider, CPT, charge, units).
+    When a row appears in both DataFrames the version from *new_df* is kept so
+    that corrected charges (e.g. updated charge amounts) replace stale ones.
+
+    Args:
+        new_df:      Newly pulled charges (already PII-stripped).
+        existing_df: Charges already stored in the database.
+
+    Returns:
+        Merged, deduplicated DataFrame.
+    """
+    if existing_df.empty:
+        return new_df.reset_index(drop=True)
+    if new_df.empty:
+        return existing_df.reset_index(drop=True)
+
+    available_keys = [
+        k for k in PC_DEDUP_KEYS
+        if k in new_df.columns and k in existing_df.columns
+    ]
+
+    if not available_keys:
+        logger.warning("No common dedup keys found — appending without deduplication")
+        return pd.concat([existing_df, new_df], ignore_index=True)
+
+    # Stack new rows first so keep='first' retains the newer version on conflict
+    combined = pd.concat([new_df, existing_df], ignore_index=True)
+    deduped = combined.drop_duplicates(subset=available_keys, keep="first")
+    logger.info(
+        "Dedup: %d new + %d existing → %d unique rows (%d duplicates removed)",
+        len(new_df), len(existing_df), len(deduped),
+        len(new_df) + len(existing_df) - len(deduped),
+    )
+    return deduped.reset_index(drop=True)
+
+
+# ── Database storage ──────────────────────────────────────────────────────────
+
+def store_csv_to_db(filename: str, csv_bytes: bytes) -> None:
+    """
+    Upsert CSV bytes into the ReferenceData table.
+
+    Mirrors the manual upload behaviour in app.py (Owner upload form) but
+    works outside a Flask application context so the CLI command can call it
+    without spinning up the full web application.
+
+    Args:
+        filename:  One of '201 Bills and Payments.csv', 'Charges Export.csv',
+                   or 'bank.csv'.
+        csv_bytes: UTF-8 encoded CSV content.
+    """
+    from sqlalchemy import create_engine, text
+
+    database_url = os.environ.get("DATABASE_URL", "")
+    if not database_url:
+        base_dir = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
+        db_path = os.path.join(base_dir, "instance", "site.db")
+        database_url = f"sqlite:///{db_path}"
+
+    if database_url.startswith("postgres://"):
+        database_url = database_url.replace("postgres://", "postgresql://", 1)
+
+    engine = create_engine(database_url)
+    now = datetime.datetime.now(datetime.timezone.utc)
+
+    with engine.begin() as conn:
+        existing = conn.execute(
+            text("SELECT id FROM reference_data WHERE filename = :f"),
+            {"f": filename},
+        ).fetchone()
+
+        if existing:
+            conn.execute(
+                text(
+                    "UPDATE reference_data SET data = :data, updated_at = :now "
+                    "WHERE filename = :f"
+                ),
+                {"data": csv_bytes, "now": now, "f": filename},
+            )
+        else:
+            conn.execute(
+                text(
+                    "INSERT INTO reference_data (filename, data, updated_at) "
+                    "VALUES (:f, :data, :now)"
+                ),
+                {"f": filename, "data": csv_bytes, "now": now},
+            )
+
+    logger.info("Stored %d bytes as '%s' in ReferenceData", len(csv_bytes), filename)
+
+
+# ── Full ingestion pipeline ───────────────────────────────────────────────────
+
+def run_ingestion_pipeline(sources: list[str] | None = None) -> dict:
+    """
+    Run the full data ingestion pipeline.
+
+    Pulls from each requested source and upserts the result into the
+    ReferenceData table so the dashboard immediately sees fresh data.
+
+    Args:
+        sources: Which sources to pull. Accepts any combination of 'va' and
+                 'pc'. Defaults to both.
+
+    Returns:
+        Dict keyed by source name. Each value has:
+          - 'status': 'ok' or 'error'
+          - 'rows':   Row count (on success)
+          - 'error':  Error message string (on failure)
+    """
+    if sources is None:
+        sources = ["va", "pc"]
+
+    results: dict = {}
+
+    if "va" in sources:
+        try:
+            csv_bytes = pull_google_sheets_va_data()
+            store_csv_to_db("201 Bills and Payments.csv", csv_bytes)
+            df = pd.read_csv(io.BytesIO(csv_bytes))
+            results["va"] = {"status": "ok", "rows": len(df)}
+            logger.info("VA ingestion complete: %d rows", len(df))
+        except Exception as exc:
+            logger.error("VA ingestion failed: %s", exc)
+            results["va"] = {"status": "error", "error": str(exc)}
+
+    if "pc" in sources:
+        try:
+            csv_bytes = pull_tebra_charges()
+            new_df = pd.read_csv(io.BytesIO(csv_bytes))
+            existing_df = _read_existing_csv_from_db("Charges Export.csv")
+            merged_df = _dedup_charges(new_df, existing_df)
+            final_csv = merged_df.to_csv(index=False).encode("utf-8")
+            store_csv_to_db("Charges Export.csv", final_csv)
+            results["pc"] = {
+                "status": "ok",
+                "rows": len(merged_df),
+                "new_rows": len(new_df),
+            }
+            logger.info("PC ingestion complete: %d total rows (%d new)", len(merged_df), len(new_df))
+        except Exception as exc:
+            logger.error("PC ingestion failed: %s", exc)
+            results["pc"] = {"status": "error", "error": str(exc)}
+
+    return results

--- a/data/owner_analytics.py
+++ b/data/owner_analytics.py
@@ -1,0 +1,265 @@
+"""
+Owner-only analytics for Jenks Family Medicine admin dashboard.
+Computes Provider Scorecards, Trend Analysis, Breakeven Analysis,
+Monthly Aggregation, and Recommendations Engine.
+"""
+import pandas as pd
+
+try:
+    from . import rvu_analytics
+except ImportError:
+    import rvu_analytics
+
+PROVIDERS = ['ANNE JENKS', 'EHRIN IRVIN', 'HEATHER MAYO', 'SARAH SUGGS']
+PROVIDER_COLORS = {
+    'Anne Jenks': '#37a4db',
+    'Ehrin Irvin': '#2ecc71',
+    'Heather Mayo': '#f39c12',
+    'Sarah Suggs': '#9b59b6',
+}
+BREAKEVEN_INDIVIDUAL = 49
+INDUSTRY_INDIVIDUAL = 82
+BREAKEVEN_COMPANY = 196
+INDUSTRY_COMPANY = 328
+
+
+def _get_adjusted_df():
+    """Return RVU dataset with Anne Jenks +216 adj applied (matches chart generation)."""
+    df = rvu_analytics.get_rvu_dataset()
+    if df.empty:
+        return df
+    unique_weeks = df['Week'].unique()
+    if len(unique_weeks) > 0:
+        extra_per_week = 216.0 / len(unique_weeks)
+        dummy = pd.DataFrame({
+            'Week': unique_weeks,
+            'Provider': 'ANNE JENKS',
+            'RVU': extra_per_week,
+            'Category': 'Manual Adjustment'
+        })
+        df = pd.concat([df, dummy], ignore_index=True)
+    return df[df['Provider'].isin(PROVIDERS)].copy()
+
+
+def _weekly_by_provider(df):
+    """Return {provider: weekly_series} and sorted all_weeks list."""
+    all_weeks = sorted([pd.Timestamp(w) for w in df['Week'].unique()])
+    prov_series = {}
+    for p in PROVIDERS:
+        pdata = df[df['Provider'] == p].groupby('Week')['RVU'].sum()
+        pdata.index = pd.DatetimeIndex(pdata.index)
+        pdata = pdata.reindex(pd.DatetimeIndex(all_weeks), fill_value=0.0)
+        prov_series[p] = pdata
+    return prov_series, all_weeks
+
+
+def get_scorecards():
+    df = _get_adjusted_df()
+    if df.empty:
+        return {}
+    prov_weekly, all_weeks = _weekly_by_provider(df)
+    result = {}
+    for p in PROVIDERS:
+        arr = prov_weekly[p].values
+        n = len(arr)
+        if n == 0:
+            continue
+        recent = float(arr[-4:].mean()) if n >= 4 else float(arr.mean())
+        prior = float(arr[-8:-4].mean()) if n >= 8 else float(arr.mean())
+        trend_pct = (recent - prior) / prior * 100 if prior > 0 else 0.0
+        trend = 'Improving' if trend_pct > 5 else ('Declining' if trend_pct < -5 else 'Stable')
+        display = p.title()
+        result[display] = {
+            'total_rvus': round(float(arr.sum()), 1),
+            'avg_weekly': round(float(arr.mean()), 1),
+            'breakeven_hit_rate': round(float((arr >= BREAKEVEN_INDIVIDUAL).mean() * 100), 1),
+            'industry_hit_rate': round(float((arr >= INDUSTRY_INDIVIDUAL).mean() * 100), 1),
+            'best_week': round(float(arr.max()), 1),
+            'worst_week': round(float(arr.min()), 1),
+            'std_dev': round(float(arr.std(ddof=1)), 1) if n > 1 else 0.0,
+            'trend': trend,
+            'trend_pct': round(trend_pct, 1),
+            'weeks_count': n,
+            'color': PROVIDER_COLORS.get(display, '#888'),
+        }
+    return result
+
+
+def get_trends():
+    df = _get_adjusted_df()
+    if df.empty:
+        return {}
+    prov_weekly, all_weeks = _weekly_by_provider(df)
+    weeks_str = [w.strftime('%Y-%m-%d') for w in all_weeks]
+    providers_out = {}
+    for p in PROVIDERS:
+        s = prov_weekly[p]
+        display = p.title()
+        providers_out[display] = {
+            'weekly': [round(float(v), 1) for v in s.values],
+            'rolling4': [round(float(v), 1) for v in s.rolling(4, min_periods=1).mean().values],
+            'cumulative': [round(float(v), 1) for v in s.cumsum().values],
+            'color': PROVIDER_COLORS.get(display, '#888'),
+        }
+    company = df.groupby('Week')['RVU'].sum()
+    company.index = pd.DatetimeIndex(company.index)
+    company = company.reindex(pd.DatetimeIndex(all_weeks), fill_value=0.0)
+    wow = company.pct_change().fillna(0).clip(-2, 2) * 100
+    return {
+        'weeks': weeks_str,
+        'providers': providers_out,
+        'company': {
+            'weekly': [round(float(v), 1) for v in company.values],
+            'wow_pct': [round(float(v), 1) for v in wow.values],
+        },
+        'benchmarks': {
+            'ind_breakeven': BREAKEVEN_INDIVIDUAL,
+            'ind_industry': INDUSTRY_INDIVIDUAL,
+            'co_breakeven': BREAKEVEN_COMPANY,
+            'co_industry': INDUSTRY_COMPANY,
+        },
+    }
+
+
+def get_breakeven_analysis():
+    df = _get_adjusted_df()
+    if df.empty:
+        return {}
+    prov_weekly, all_weeks = _weekly_by_provider(df)
+    weeks_str = [w.strftime('%Y-%m-%d') for w in all_weeks]
+    company = df.groupby('Week')['RVU'].sum()
+    company.index = pd.DatetimeIndex(company.index)
+    company = company.reindex(pd.DatetimeIndex(all_weeks), fill_value=0.0)
+    co_dist = [round(float(v - BREAKEVEN_COMPANY), 1) for v in company.values]
+    providers_out = {}
+    for p in PROVIDERS:
+        arr = prov_weekly[p].values
+        display = p.title()
+        dist = [round(float(v - BREAKEVEN_INDIVIDUAL), 1) for v in arr]
+        providers_out[display] = {
+            'distances': dist,
+            'hit_rate': round(float((arr >= BREAKEVEN_INDIVIDUAL).mean() * 100), 1),
+            'industry_hit_rate': round(float((arr >= INDUSTRY_INDIVIDUAL).mean() * 100), 1),
+            'avg_weekly': round(float(arr.mean()), 1),
+            'color': PROVIDER_COLORS.get(display, '#888'),
+        }
+    return {
+        'weeks': weeks_str,
+        'company_distances': co_dist,
+        'providers': providers_out,
+    }
+
+
+def get_monthly():
+    df = _get_adjusted_df()
+    if df.empty:
+        return {}
+    df = df.copy()
+    df['Month'] = pd.to_datetime(df['Week']).dt.to_period('M')
+    all_months = sorted(df['Month'].unique())
+    months_str = [m.strftime('%b %Y') for m in all_months]
+    weeks_per_month = {m: int(df[df['Month'] == m]['Week'].nunique()) for m in all_months}
+    company = df.groupby('Month')['RVU'].sum().reindex(all_months, fill_value=0.0)
+    providers_out = {}
+    for p in PROVIDERS:
+        s = df[df['Provider'] == p].groupby('Month')['RVU'].sum().reindex(all_months, fill_value=0.0)
+        display = p.title()
+        providers_out[display] = {
+            'values': [round(float(v), 1) for v in s.values],
+            'color': PROVIDER_COLORS.get(display, '#888'),
+        }
+    return {
+        'months': months_str,
+        'providers': providers_out,
+        'company_total': [round(float(v), 1) for v in company.values],
+        'company_breakeven': [weeks_per_month.get(m, 4) * BREAKEVEN_COMPANY for m in all_months],
+        'company_industry': [weeks_per_month.get(m, 4) * INDUSTRY_COMPANY for m in all_months],
+    }
+
+
+def get_recommendations():
+    df = _get_adjusted_df()
+    if df.empty:
+        return [{'type': 'info', 'text': 'No data available. Upload CSV files to generate recommendations.'}]
+
+    prov_weekly, all_weeks = _weekly_by_provider(df)
+    company = df.groupby('Week')['RVU'].sum()
+    company.index = pd.DatetimeIndex(company.index)
+    company = company.reindex(pd.DatetimeIndex(all_weeks), fill_value=0.0)
+    insights = []
+    co_avg = float(company.mean())
+
+    # Company status
+    if co_avg >= BREAKEVEN_COMPANY:
+        insights.append({'type': 'success',
+                         'text': f"Company-wide production is on target at {co_avg:.1f} avg RVUs/week (breakeven: {BREAKEVEN_COMPANY})."})
+    else:
+        gap = BREAKEVEN_COMPANY - co_avg
+        insights.append({'type': 'warning',
+                         'text': f"Company-wide average of {co_avg:.1f} RVUs/week is {gap:.1f} below the {BREAKEVEN_COMPANY} breakeven target."})
+
+    prov_avgs = {}
+    for p in PROVIDERS:
+        arr = prov_weekly[p].values
+        n = len(arr)
+        display = p.title()
+        avg = float(arr.mean())
+        prov_avgs[display] = avg
+
+        if avg < BREAKEVEN_INDIVIDUAL:
+            gap = BREAKEVEN_INDIVIDUAL - avg
+            insights.append({'type': 'alert',
+                             'text': f"{display} is averaging {avg:.1f} RVUs/week — {gap:.1f} below the individual breakeven ({BREAKEVEN_INDIVIDUAL})."})
+        elif avg >= INDUSTRY_INDIVIDUAL:
+            insights.append({'type': 'success',
+                             'text': f"{display} is at or above the industry standard ({INDUSTRY_INDIVIDUAL} RVUs/week), averaging {avg:.1f}."})
+
+        if n >= 8:
+            recent = float(arr[-4:].mean())
+            prior = float(arr[-8:-4].mean())
+            if prior > 0:
+                pct = (recent - prior) / prior * 100
+                if pct <= -20:
+                    insights.append({'type': 'alert',
+                                     'text': f"{display}'s production has declined {abs(pct):.0f}% over the last 4 weeks vs the prior 4 weeks."})
+                elif pct >= 20:
+                    insights.append({'type': 'success',
+                                     'text': f"{display} is trending up {pct:.0f}% over the last 4 weeks vs the prior 4 weeks."})
+
+        if n > 2:
+            std = float(arr.std(ddof=1))
+            cv = std / avg if avg > 0 else 0
+            if cv > 0.6:
+                insights.append({'type': 'info',
+                                 'text': f"{display} shows high week-to-week variability (std dev: {std:.1f} RVUs). Consistent scheduling may help."})
+
+    if prov_avgs:
+        top = max(prov_avgs, key=prov_avgs.get)
+        bot = min(prov_avgs, key=prov_avgs.get)
+        if top != bot:
+            insights.append({'type': 'info',
+                             'text': f"Top performer: {top} ({prov_avgs[top]:.1f} avg RVUs/week). Lowest: {bot} ({prov_avgs[bot]:.1f} avg RVUs/week)."})
+
+    # Detect holiday/low-production weeks
+    threshold = co_avg * 0.5
+    low_weeks = company[company < threshold]
+    if len(low_weeks) > 0:
+        dates = []
+        for w in low_weeks.index[:3]:
+            dt = pd.Timestamp(w)
+            dates.append(f"{dt.strftime('%b')} {dt.day}")
+        extra = f" (+{len(low_weeks) - 3} more)" if len(low_weeks) > 3 else ""
+        insights.append({'type': 'info',
+                         'text': f"Low-production weeks detected (likely holidays/closures): {', '.join(dates)}{extra}."})
+
+    return insights
+
+
+def get_all_analytics():
+    return {
+        'scorecards': get_scorecards(),
+        'trends': get_trends(),
+        'breakeven': get_breakeven_analysis(),
+        'monthly': get_monthly(),
+        'recommendations': get_recommendations(),
+    }

--- a/data/tests/test_data_ingestion.py
+++ b/data/tests/test_data_ingestion.py
@@ -1,0 +1,1124 @@
+"""
+Tests for data/data_ingestion.py
+
+Coverage:
+  - PII stripping (whitelist approach — only safe fields survive)
+  - CPT to RVU mapping (exact, pattern, description fallback, unknown)
+  - SOAP request building (valid XML, credential escaping)
+  - Tebra response parsing (happy path, empty, invalid XML)
+  - Tebra charge normalisation (column mapping, missing fields)
+  - Google Sheets data parsing (mocked API, empty sheet)
+  - Error handling (missing env vars, HTTP failure, API errors)
+  - run_ingestion_pipeline integration (mocked sub-functions)
+"""
+
+import io
+import os
+import sys
+import unittest
+from unittest.mock import MagicMock, patch
+import xml.etree.ElementTree as ET
+
+import pandas as pd
+import requests
+
+# Add data/ to path so we can import data_ingestion directly
+sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
+import data_ingestion
+from data_ingestion import (
+    TEBRA_PII_FIELDS,
+    TEBRA_SAFE_FIELDS,
+    CPT_RVU_MAP,
+    _strip_pii_from_charge,
+    _build_get_charges_request,
+    _parse_charges_response,
+    _normalize_tebra_charges,
+    cpt_to_rvu,
+    pull_tebra_charges,
+    pull_google_sheets_va_data,
+    run_ingestion_pipeline,
+)
+
+
+# ── PII Stripping ─────────────────────────────────────────────────────────────
+
+class TestStripPii(unittest.TestCase):
+    """_strip_pii_from_charge must use a whitelist: only TEBRA_SAFE_FIELDS survive."""
+
+    def _full_charge(self) -> dict:
+        """Return a charge dict with both PII and safe fields."""
+        pii = {f: f"value_{f}" for f in TEBRA_PII_FIELDS}
+        safe = {f: f"value_{f}" for f in TEBRA_SAFE_FIELDS}
+        return {**pii, **safe}
+
+    def test_all_pii_fields_removed(self):
+        charge = self._full_charge()
+        result = _strip_pii_from_charge(charge)
+        for pii_field in TEBRA_PII_FIELDS:
+            self.assertNotIn(pii_field, result, f"PII field '{pii_field}' survived stripping")
+
+    def test_all_safe_fields_retained(self):
+        charge = self._full_charge()
+        result = _strip_pii_from_charge(charge)
+        for safe_field in TEBRA_SAFE_FIELDS:
+            self.assertIn(safe_field, result, f"Safe field '{safe_field}' was incorrectly removed")
+
+    def test_unknown_fields_dropped(self):
+        """Fields not in either list must also be dropped (whitelist, not blacklist)."""
+        charge = {
+            "ServiceDate": "2025-01-01",
+            "SomeRandomUnknownField": "secret",
+            "AnotherUnknownField": "data",
+        }
+        result = _strip_pii_from_charge(charge)
+        self.assertIn("ServiceDate", result)
+        self.assertNotIn("SomeRandomUnknownField", result)
+        self.assertNotIn("AnotherUnknownField", result)
+
+    def test_empty_charge_returns_empty(self):
+        self.assertEqual(_strip_pii_from_charge({}), {})
+
+    def test_only_pii_returns_empty(self):
+        charge = {f: "value" for f in TEBRA_PII_FIELDS}
+        self.assertEqual(_strip_pii_from_charge(charge), {})
+
+    def test_specific_pii_fields_blocked(self):
+        """Spot-check the most sensitive fields by name."""
+        sensitive = [
+            "PatientFirstName", "PatientLastName", "PatientDOB",
+            "PatientSSN", "PatientAddress", "PatientPhone", "PatientEmail",
+        ]
+        charge = {f: "secret" for f in sensitive}
+        charge["ServiceDate"] = "2025-01-01"
+        result = _strip_pii_from_charge(charge)
+        for field in sensitive:
+            self.assertNotIn(field, result)
+        self.assertIn("ServiceDate", result)
+
+    def test_return_is_new_dict(self):
+        """Stripping must not mutate the original dict."""
+        charge = {"ServiceDate": "2025-01-01", "PatientFirstName": "Jane"}
+        original = dict(charge)
+        _strip_pii_from_charge(charge)
+        self.assertEqual(charge, original)
+
+
+# ── CPT → RVU Mapping ────────────────────────────────────────────────────────
+
+class TestCptToRvu(unittest.TestCase):
+
+    def test_exact_lookup_e_and_m(self):
+        self.assertAlmostEqual(cpt_to_rvu("99213"), 1.30)
+        self.assertAlmostEqual(cpt_to_rvu("99215"), 2.80)
+        self.assertAlmostEqual(cpt_to_rvu("99214"), 1.92)
+
+    def test_exact_lookup_new_patient(self):
+        self.assertAlmostEqual(cpt_to_rvu("99203"), 1.42)
+        self.assertAlmostEqual(cpt_to_rvu("99205"), 3.17)
+
+    def test_exact_lookup_nexus_letter(self):
+        self.assertAlmostEqual(cpt_to_rvu("99080"), 2.50)
+
+    def test_exact_lookup_dot_physical(self):
+        self.assertAlmostEqual(cpt_to_rvu("99455"), 1.77)
+
+    def test_exact_lookup_vaccine_admin(self):
+        self.assertAlmostEqual(cpt_to_rvu("90471"), 0.17)
+        self.assertAlmostEqual(cpt_to_rvu("90472"), 0.15)
+
+    def test_pattern_em_range(self):
+        # 992[01][1-5] — established/new patient E&M range not in exact map
+        self.assertAlmostEqual(cpt_to_rvu("99211"), 0.18)  # in exact map
+
+    def test_pattern_annual_range(self):
+        # 993xx preventive codes
+        self.assertAlmostEqual(cpt_to_rvu("99391"), 1.30)  # not in exact map → pattern
+
+    def test_pattern_vaccine_admin_range(self):
+        # 90[4-7][0-9]{2} catch-all for vaccine codes not in exact map
+        self.assertAlmostEqual(cpt_to_rvu("90460"), 0.50)
+
+    def test_description_functional_initial(self):
+        self.assertAlmostEqual(cpt_to_rvu("XXXXX", "Functional Medicine Initial"), 3.75)
+
+    def test_description_functional_subsequent(self):
+        self.assertAlmostEqual(cpt_to_rvu("XXXXX", "Functional Medicine Subsequent Visit"), 2.50)
+
+    def test_description_nexus(self):
+        self.assertAlmostEqual(cpt_to_rvu("XXXXX", "Nexus Letter"), 2.50)
+
+    def test_description_dot_physical(self):
+        self.assertAlmostEqual(cpt_to_rvu("XXXXX", "DOT Physical Exam"), 1.0)
+
+    def test_description_annual(self):
+        self.assertAlmostEqual(cpt_to_rvu("XXXXX", "Annual Wellness Visit"), 1.30)
+
+    def test_description_vaccine(self):
+        self.assertAlmostEqual(cpt_to_rvu("XXXXX", "Vaccine Administration"), 0.50)
+
+    def test_unknown_returns_zero(self):
+        self.assertAlmostEqual(cpt_to_rvu("00000"), 0.0)
+        self.assertAlmostEqual(cpt_to_rvu("ZZZZZ", ""), 0.0)
+
+    def test_case_insensitive_description(self):
+        self.assertAlmostEqual(
+            cpt_to_rvu("XXXXX", "FUNCTIONAL MEDICINE INITIAL"),
+            cpt_to_rvu("XXXXX", "functional medicine initial"),
+        )
+
+    def test_whitespace_stripped_from_code(self):
+        self.assertAlmostEqual(cpt_to_rvu(" 99213 "), cpt_to_rvu("99213"))
+
+    def test_all_map_entries_non_negative(self):
+        for code, rvu in CPT_RVU_MAP.items():
+            self.assertGreaterEqual(rvu, 0.0, f"CPT {code} has negative RVU")
+
+
+# ── SOAP Request Building ─────────────────────────────────────────────────────
+
+class TestBuildGetChargesRequest(unittest.TestCase):
+
+    def test_valid_xml(self):
+        xml_str = _build_get_charges_request("KEY123", "2025-01-01", "2025-03-31")
+        root = ET.fromstring(xml_str)  # raises if invalid
+        self.assertIsNotNone(root)
+
+    def test_contains_api_key(self):
+        xml_str = _build_get_charges_request("MYKEY", "2025-01-01", "2025-01-31")
+        self.assertIn("MYKEY", xml_str)
+
+    def test_contains_date_range(self):
+        xml_str = _build_get_charges_request("K", "2025-02-01", "2025-02-28")
+        self.assertIn("2025-02-01", xml_str)
+        self.assertIn("2025-02-28", xml_str)
+
+    def test_xml_special_chars_escaped(self):
+        """Credentials with XML special characters must be escaped."""
+        xml_str = _build_get_charges_request(
+            "key&val", "2025-01-01", "2025-01-31",
+            username="user<test>", password="pass'word\"here",
+        )
+        # Should still be parseable
+        root = ET.fromstring(xml_str)
+        self.assertIsNotNone(root)
+        # Raw special chars must not appear unescaped
+        self.assertNotIn("key&val", xml_str)   # & must be &amp;
+        self.assertNotIn("user<test>", xml_str)  # < must be &lt;
+
+    def test_soap_action_present_in_structure(self):
+        xml_str = _build_get_charges_request("K", "2025-01-01", "2025-01-31")
+        self.assertIn("GetCharges", xml_str)
+        self.assertIn("soap:Body", xml_str)
+
+
+# ── Tebra Response Parsing ────────────────────────────────────────────────────
+
+_SAMPLE_RESPONSE_ONE_CHARGE = """<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <GetChargesResponse xmlns="http://www.kareo.com/api/schemas/">
+      <GetChargesResult>
+        <Charges>
+          <Charge>
+            <ServiceDate>2025-01-15</ServiceDate>
+            <PatientFirstName>John</PatientFirstName>
+            <PatientLastName>Doe</PatientLastName>
+            <PatientDOB>1980-06-01</PatientDOB>
+            <PatientSSN>123-45-6789</PatientSSN>
+            <PatientAddress>123 Main St</PatientAddress>
+            <PatientPhone>555-0100</PatientPhone>
+            <PatientEmail>jdoe@example.com</PatientEmail>
+            <ProcedureCode>99213</ProcedureCode>
+            <ChargeAmount>150.00</ChargeAmount>
+            <RenderingProviderName>Anne Jenks</RenderingProviderName>
+            <FacilityName>JFM Clinic</FacilityName>
+            <Units>1</Units>
+          </Charge>
+        </Charges>
+      </GetChargesResult>
+    </GetChargesResponse>
+  </soap:Body>
+</soap:Envelope>"""
+
+_SAMPLE_RESPONSE_EMPTY = """<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <GetChargesResponse xmlns="http://www.kareo.com/api/schemas/">
+      <GetChargesResult>
+        <Charges />
+      </GetChargesResult>
+    </GetChargesResponse>
+  </soap:Body>
+</soap:Envelope>"""
+
+_SAMPLE_RESPONSE_TWO_CHARGES = """<?xml version="1.0" encoding="utf-8"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <GetChargesResponse xmlns="http://www.kareo.com/api/schemas/">
+      <GetChargesResult>
+        <Charges>
+          <Charge>
+            <ServiceDate>2025-02-01</ServiceDate>
+            <PatientFirstName>Alice</PatientFirstName>
+            <ProcedureCode>99214</ProcedureCode>
+            <ChargeAmount>200.00</ChargeAmount>
+            <RenderingProviderName>Ehrin Irvin</RenderingProviderName>
+            <Units>1</Units>
+          </Charge>
+          <Charge>
+            <ServiceDate>2025-02-03</ServiceDate>
+            <PatientLastName>Smith</PatientLastName>
+            <PatientSSN>987-65-4321</PatientSSN>
+            <ProcedureCode>90471</ProcedureCode>
+            <ChargeAmount>25.00</ChargeAmount>
+            <RenderingProviderName>Sarah Suggs</RenderingProviderName>
+            <Units>1</Units>
+          </Charge>
+        </Charges>
+      </GetChargesResult>
+    </GetChargesResponse>
+  </soap:Body>
+</soap:Envelope>"""
+
+
+class TestParseChargesResponse(unittest.TestCase):
+
+    def test_single_charge_parsed(self):
+        charges = _parse_charges_response(_SAMPLE_RESPONSE_ONE_CHARGE)
+        self.assertEqual(len(charges), 1)
+
+    def test_pii_stripped_from_response(self):
+        charges = _parse_charges_response(_SAMPLE_RESPONSE_ONE_CHARGE)
+        charge = charges[0]
+        for pii in ["PatientFirstName", "PatientLastName", "PatientDOB",
+                    "PatientSSN", "PatientAddress", "PatientPhone", "PatientEmail"]:
+            self.assertNotIn(pii, charge, f"PII field '{pii}' survived parsing")
+
+    def test_safe_fields_present(self):
+        charges = _parse_charges_response(_SAMPLE_RESPONSE_ONE_CHARGE)
+        charge = charges[0]
+        self.assertEqual(charge["ServiceDate"], "2025-01-15")
+        self.assertEqual(charge["ProcedureCode"], "99213")
+        self.assertEqual(charge["ChargeAmount"], "150.00")
+        self.assertEqual(charge["RenderingProviderName"], "Anne Jenks")
+
+    def test_empty_charges_returns_empty_list(self):
+        charges = _parse_charges_response(_SAMPLE_RESPONSE_EMPTY)
+        self.assertEqual(charges, [])
+
+    def test_two_charges_parsed(self):
+        charges = _parse_charges_response(_SAMPLE_RESPONSE_TWO_CHARGES)
+        self.assertEqual(len(charges), 2)
+        # Verify PII stripped from both
+        for charge in charges:
+            for pii in ["PatientFirstName", "PatientLastName", "PatientSSN"]:
+                self.assertNotIn(pii, charge)
+
+    def test_invalid_xml_raises_value_error(self):
+        with self.assertRaises(ValueError, msg="Expected ValueError for invalid XML"):
+            _parse_charges_response("this is not xml at all <<<")
+
+    def test_namespace_stripping(self):
+        """Parser must handle namespace-qualified element names."""
+        xml_ns = """<?xml version="1.0"?>
+<s:Envelope xmlns:s="http://schemas.xmlsoap.org/soap/envelope/"
+            xmlns:k="http://www.kareo.com/api/schemas/">
+  <s:Body>
+    <k:GetChargesResponse>
+      <k:GetChargesResult>
+        <k:Charges>
+          <k:Charge>
+            <k:ServiceDate>2025-03-01</k:ServiceDate>
+            <k:ProcedureCode>99215</k:ProcedureCode>
+            <k:PatientFirstName>Hidden</k:PatientFirstName>
+          </k:Charge>
+        </k:Charges>
+      </k:GetChargesResult>
+    </k:GetChargesResponse>
+  </s:Body>
+</s:Envelope>"""
+        charges = _parse_charges_response(xml_ns)
+        self.assertEqual(len(charges), 1)
+        self.assertNotIn("PatientFirstName", charges[0])
+        self.assertEqual(charges[0].get("ServiceDate"), "2025-03-01")
+
+    def test_chargedto_tag_also_parsed(self):
+        """Parser must handle 'ChargeDTO' element name used by some Tebra versions."""
+        xml = """<?xml version="1.0"?>
+<Envelope>
+  <Body>
+    <ChargeDTO>
+      <ServiceDate>2025-04-01</ServiceDate>
+      <ProcedureCode>99214</ProcedureCode>
+      <PatientFirstName>Hidden</PatientFirstName>
+    </ChargeDTO>
+  </Body>
+</Envelope>"""
+        charges = _parse_charges_response(xml)
+        self.assertEqual(len(charges), 1)
+        self.assertNotIn("PatientFirstName", charges[0])
+
+
+# ── Tebra Charge Normalisation ────────────────────────────────────────────────
+
+class TestNormalizeTebraCharges(unittest.TestCase):
+
+    def test_column_renaming(self):
+        charges = [{
+            "ServiceDate": "2025-01-15",
+            "ProcedureCode": "99213",
+            "ChargeAmount": "150.00",
+            "RenderingProviderName": "Anne Jenks",
+            "Units": "1",
+            "FacilityName": "JFM",
+        }]
+        df = _normalize_tebra_charges(charges)
+        self.assertIn("Date Of Service", df.columns)
+        self.assertIn("Procedure Codes with Modifiers", df.columns)
+        self.assertIn("Service Charge Amount", df.columns)
+        self.assertIn("Rendering Provider", df.columns)
+        self.assertIn("Facility Name", df.columns)
+
+    def test_required_columns_added_when_missing(self):
+        charges = [{"ServiceDate": "2025-01-15"}]
+        df = _normalize_tebra_charges(charges)
+        for col in ["Date Of Service", "Rendering Provider",
+                    "Procedure Codes with Modifiers", "Service Charge Amount", "Units"]:
+            self.assertIn(col, df.columns)
+
+    def test_empty_list_returns_dataframe_with_columns(self):
+        df = _normalize_tebra_charges([])
+        # Must not raise; returns empty-ish DataFrame
+        self.assertIsInstance(df, pd.DataFrame)
+
+    def test_values_preserved_after_rename(self):
+        charges = [{"ServiceDate": "2025-03-10", "ChargeAmount": "75.00"}]
+        df = _normalize_tebra_charges(charges)
+        self.assertEqual(df["Date Of Service"].iloc[0], "2025-03-10")
+        self.assertEqual(df["Service Charge Amount"].iloc[0], "75.00")
+
+    def test_insurance_columns_mapped(self):
+        charges = [{
+            "ServiceDate": "2025-01-01",
+            "InsuranceContractAdjustment": "-50.00",
+            "InsurancePaymentAmount": "100.00",
+            "PatientPaymentAmount": "20.00",
+        }]
+        df = _normalize_tebra_charges(charges)
+        self.assertIn("Pri Ins Insurance Contract Adjustment", df.columns)
+        self.assertIn("Pri Ins Insurance Payment", df.columns)
+        self.assertIn("Pat Payment Amount", df.columns)
+
+
+# ── Google Sheets Parsing ─────────────────────────────────────────────────────
+
+class TestPullGoogleSheetsVaData(unittest.TestCase):
+
+    def _mock_service(self, values):
+        """Helper: build a mock Sheets service that returns the given values."""
+        mock_service = MagicMock()
+        (mock_service.spreadsheets.return_value
+                     .values.return_value
+                     .get.return_value
+                     .execute.return_value) = {"values": values}
+        return mock_service
+
+    @patch("data_ingestion._get_sheets_service")
+    def test_happy_path_returns_csv_bytes(self, mock_factory):
+        mock_factory.return_value = self._mock_service([
+            ["Date of Service", "Provider", "Focused DBQs", "Routine IMOs",
+             "Gen Med DBQs", "TBI", "No Show"],
+            ["01/15/2025", "Sarah Suggs", "1-5", "1-3", "0", "0", "0"],
+            ["01/16/2025", "Anne Jenks", "0", "0", "1-5", "0", "0"],
+        ])
+        result = pull_google_sheets_va_data("fake-id")
+        self.assertIsInstance(result, bytes)
+        df = pd.read_csv(io.BytesIO(result))
+        self.assertEqual(len(df), 2)
+        self.assertIn("Date of Service", df.columns)
+        self.assertIn("Provider", df.columns)
+
+    @patch("data_ingestion._get_sheets_service")
+    def test_empty_values_raises_value_error(self, mock_factory):
+        mock_factory.return_value = self._mock_service([])
+        with self.assertRaises(ValueError, msg="Should raise on empty sheet"):
+            pull_google_sheets_va_data("fake-id")
+
+    @patch("data_ingestion._get_sheets_service")
+    def test_header_only_raises_value_error(self, mock_factory):
+        mock_factory.return_value = self._mock_service([
+            ["Date of Service", "Provider"]
+        ])
+        with self.assertRaises(ValueError, msg="Should raise when no data rows"):
+            pull_google_sheets_va_data("fake-id")
+
+    @patch("data_ingestion._get_sheets_service")
+    def test_short_rows_padded(self, mock_factory):
+        """Rows with fewer columns than the header must not crash the parser."""
+        mock_factory.return_value = self._mock_service([
+            ["Date of Service", "Provider", "Focused DBQs", "Routine IMOs"],
+            ["01/15/2025", "Sarah Suggs"],  # only 2 of 4 columns
+        ])
+        result = pull_google_sheets_va_data("fake-id")
+        df = pd.read_csv(io.BytesIO(result))
+        self.assertEqual(len(df), 1)
+        # Empty padding becomes NaN when read back through CSV
+        self.assertTrue(pd.isna(df["Focused DBQs"].iloc[0]) or df["Focused DBQs"].iloc[0] == "")
+
+    @patch("data_ingestion._get_sheets_service")
+    def test_blank_rows_dropped(self, mock_factory):
+        mock_factory.return_value = self._mock_service([
+            ["Date of Service", "Provider"],
+            ["01/15/2025", "Sarah Suggs"],
+            ["", ""],          # blank row
+            ["01/16/2025", "Anne Jenks"],
+        ])
+        result = pull_google_sheets_va_data("fake-id")
+        df = pd.read_csv(io.BytesIO(result))
+        self.assertEqual(len(df), 2)
+
+    @patch("data_ingestion._get_sheets_service")
+    def test_api_failure_raises_runtime_error(self, mock_factory):
+        mock_service = MagicMock()
+        (mock_service.spreadsheets.return_value
+                     .values.return_value
+                     .get.return_value
+                     .execute.side_effect) = Exception("quota exceeded")
+        mock_factory.return_value = mock_service
+        with self.assertRaises(RuntimeError, msg="Should wrap API exceptions"):
+            pull_google_sheets_va_data("fake-id")
+
+    def test_missing_credentials_raises_value_error(self):
+        env = {k: v for k, v in os.environ.items() if k != "GOOGLE_SHEETS_CREDENTIALS"}
+        google_mocks = {
+            "google": MagicMock(),
+            "google.oauth2": MagicMock(),
+            "google.oauth2.service_account": MagicMock(),
+            "googleapiclient": MagicMock(),
+            "googleapiclient.discovery": MagicMock(),
+        }
+        with patch.dict(os.environ, env, clear=True), \
+             patch.dict("sys.modules", google_mocks):
+            with self.assertRaisesRegex(ValueError, "GOOGLE_SHEETS_CREDENTIALS"):
+                data_ingestion._get_sheets_service()
+
+
+# ── Error Handling ────────────────────────────────────────────────────────────
+
+class TestTebraErrorHandling(unittest.TestCase):
+
+    def test_missing_api_key_raises_value_error(self):
+        env = {k: v for k, v in os.environ.items() if k != "TEBRAKEY"}
+        with patch.dict(os.environ, env, clear=True):
+            with self.assertRaisesRegex(ValueError, "TEBRAKEY"):
+                pull_tebra_charges()
+
+    def test_empty_api_key_raises_value_error(self):
+        with patch.dict(os.environ, {"TEBRAKEY": ""}, clear=False):
+            with self.assertRaisesRegex(ValueError, "TEBRAKEY"):
+                pull_tebra_charges()
+
+    @patch("requests.post")
+    def test_http_failure_raises_runtime_error(self, mock_post):
+        mock_post.side_effect = requests.RequestException("Connection refused")
+        with patch.dict(os.environ, {"TEBRAKEY": "test-key"}):
+            with self.assertRaisesRegex(RuntimeError, "Tebra API request failed"):
+                pull_tebra_charges()
+
+    @patch("requests.post")
+    def test_http_status_error_raises_runtime_error(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.raise_for_status.side_effect = requests.HTTPError("500 Server Error")
+        mock_post.return_value = mock_response
+        with patch.dict(os.environ, {"TEBRAKEY": "test-key"}):
+            with self.assertRaisesRegex(RuntimeError, "Tebra API request failed"):
+                pull_tebra_charges()
+
+    @patch("requests.post")
+    def test_empty_response_returns_empty_csv(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.text = _SAMPLE_RESPONSE_EMPTY
+        mock_post.return_value = mock_response
+        with patch.dict(os.environ, {"TEBRAKEY": "test-key"}):
+            result = pull_tebra_charges()
+        df = pd.read_csv(io.BytesIO(result))
+        self.assertEqual(len(df), 0)
+        self.assertIn("Date Of Service", df.columns)
+
+    @patch("requests.post")
+    def test_valid_response_returns_csv_bytes(self, mock_post):
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.text = _SAMPLE_RESPONSE_TWO_CHARGES
+        mock_post.return_value = mock_response
+        with patch.dict(os.environ, {"TEBRAKEY": "test-key"}):
+            result = pull_tebra_charges()
+        self.assertIsInstance(result, bytes)
+        df = pd.read_csv(io.BytesIO(result))
+        self.assertEqual(len(df), 2)
+
+    @patch("requests.post")
+    def test_result_csv_contains_no_pii_columns(self, mock_post):
+        """Final CSV output from pull_tebra_charges must not have any PII column names."""
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.text = _SAMPLE_RESPONSE_ONE_CHARGE
+        mock_post.return_value = mock_response
+        with patch.dict(os.environ, {"TEBRAKEY": "test-key"}):
+            result = pull_tebra_charges()
+        df = pd.read_csv(io.BytesIO(result))
+        for pii_field in TEBRA_PII_FIELDS:
+            self.assertNotIn(pii_field, df.columns, f"PII column '{pii_field}' in output CSV")
+
+    @patch("requests.post")
+    def test_default_date_range_covers_90_days(self, mock_post):
+        """Without explicit dates, the request should cover ~90 days ending today."""
+        captured = {}
+
+        def capture(*args, **kwargs):
+            captured["data"] = kwargs.get("data", args[1] if len(args) > 1 else b"")
+            mock_response = MagicMock()
+            mock_response.raise_for_status = MagicMock()
+            mock_response.text = _SAMPLE_RESPONSE_EMPTY
+            return mock_response
+
+        mock_post.side_effect = capture
+        with patch.dict(os.environ, {"TEBRAKEY": "test-key"}):
+            pull_tebra_charges()
+
+        from datetime import datetime, timedelta
+        today = datetime.today().strftime("%Y-%m-%d")
+        ninety_ago = (datetime.today() - timedelta(days=90)).strftime("%Y-%m-%d")
+        xml_str = captured["data"].decode("utf-8")
+        self.assertIn(today, xml_str)
+        self.assertIn(ninety_ago, xml_str)
+
+
+# ── Pipeline Integration ──────────────────────────────────────────────────────
+
+class TestRunIngestionPipeline(unittest.TestCase):
+
+    @patch("data_ingestion.store_csv_to_db")
+    @patch("data_ingestion.pull_tebra_charges")
+    @patch("data_ingestion.pull_google_sheets_va_data")
+    def test_both_sources_pulled_by_default(self, mock_va, mock_pc, mock_store):
+        mock_va.return_value = b"Date of Service,Provider\n2025-01-01,Anne Jenks\n"
+        mock_pc.return_value = (
+            b"Date Of Service,Rendering Provider,Procedure Codes with Modifiers,"
+            b"Service Charge Amount,Units\n2025-01-01,Anne Jenks,99213,150.00,1\n"
+        )
+        results = run_ingestion_pipeline()
+        mock_va.assert_called_once()
+        mock_pc.assert_called_once()
+        self.assertEqual(results["va"]["status"], "ok")
+        self.assertEqual(results["pc"]["status"], "ok")
+        self.assertEqual(results["va"]["rows"], 1)
+        self.assertEqual(results["pc"]["rows"], 1)
+
+    @patch("data_ingestion.store_csv_to_db")
+    @patch("data_ingestion.pull_tebra_charges")
+    @patch("data_ingestion.pull_google_sheets_va_data")
+    def test_va_only(self, mock_va, mock_pc, mock_store):
+        mock_va.return_value = b"Date of Service,Provider\n2025-01-01,Sarah Suggs\n"
+        results = run_ingestion_pipeline(sources=["va"])
+        mock_va.assert_called_once()
+        mock_pc.assert_not_called()
+        self.assertIn("va", results)
+        self.assertNotIn("pc", results)
+
+    @patch("data_ingestion.store_csv_to_db")
+    @patch("data_ingestion.pull_tebra_charges")
+    @patch("data_ingestion.pull_google_sheets_va_data")
+    def test_pc_only(self, mock_va, mock_pc, mock_store):
+        mock_pc.return_value = (
+            b"Date Of Service,Rendering Provider,Procedure Codes with Modifiers,"
+            b"Service Charge Amount,Units\n"
+        )
+        results = run_ingestion_pipeline(sources=["pc"])
+        mock_va.assert_not_called()
+        mock_pc.assert_called_once()
+        self.assertIn("pc", results)
+        self.assertNotIn("va", results)
+
+    @patch("data_ingestion.store_csv_to_db")
+    @patch("data_ingestion.pull_tebra_charges")
+    @patch("data_ingestion.pull_google_sheets_va_data")
+    def test_va_failure_does_not_block_pc(self, mock_va, mock_pc, mock_store):
+        mock_va.side_effect = RuntimeError("Google Sheets API down")
+        mock_pc.return_value = (
+            b"Date Of Service,Rendering Provider,Procedure Codes with Modifiers,"
+            b"Service Charge Amount,Units\n"
+        )
+        results = run_ingestion_pipeline()
+        self.assertEqual(results["va"]["status"], "error")
+        self.assertIn("Google Sheets API down", results["va"]["error"])
+        self.assertEqual(results["pc"]["status"], "ok")
+
+    @patch("data_ingestion.store_csv_to_db")
+    @patch("data_ingestion.pull_tebra_charges")
+    @patch("data_ingestion.pull_google_sheets_va_data")
+    def test_store_called_with_correct_filenames(self, mock_va, mock_pc, mock_store):
+        mock_va.return_value = b"Date of Service,Provider\n"
+        mock_pc.return_value = (
+            b"Date Of Service,Rendering Provider,Procedure Codes with Modifiers,"
+            b"Service Charge Amount,Units\n"
+        )
+        run_ingestion_pipeline()
+        stored_filenames = {call.args[0] for call in mock_store.call_args_list}
+        self.assertIn("201 Bills and Payments.csv", stored_filenames)
+        self.assertIn("Charges Export.csv", stored_filenames)
+
+    @patch("data_ingestion.store_csv_to_db")
+    @patch("data_ingestion.pull_tebra_charges")
+    @patch("data_ingestion.pull_google_sheets_va_data")
+    def test_both_sources_fail_returns_errors(self, mock_va, mock_pc, mock_store):
+        mock_va.side_effect = ValueError("No credentials")
+        mock_pc.side_effect = ValueError("No API key")
+        results = run_ingestion_pipeline()
+        self.assertEqual(results["va"]["status"], "error")
+        self.assertEqual(results["pc"]["status"], "error")
+
+
+# ── Enhanced PII Rigour ───────────────────────────────────────────────────────
+#
+# HIPAA-adjacent requirement: patient data must NEVER survive the pipeline.
+# These tests use realistic fake PII values and verify they are absent from
+# every stage of output — including the final CSV bytes stored in the database.
+
+from data_ingestion import _dedup_charges, PC_DEDUP_KEYS
+
+# Realistic fake PII values used as "canary" strings.
+_FAKE_PII = {
+    "PatientFirstName":   "Jane",
+    "PatientLastName":    "Testpatient",
+    "PatientDOB":         "1978-04-22",
+    "PatientSSN":         "987-65-4321",
+    "PatientAddress":     "456 Elm Street",
+    "PatientAddress2":    "Apt 7B",
+    "PatientCity":        "Springfield",
+    "PatientState":       "IL",
+    "PatientZip":         "62701",
+    "PatientPhone":       "555-867-5309",
+    "PatientCellPhone":   "555-867-5310",
+    "PatientEmail":       "jane.testpatient@example.com",
+    "GuarantorFirstName": "Robert",
+    "GuarantorLastName":  "Testguarantor",
+    "GuarantorAddress":   "789 Oak Ave",
+    "GuarantorPhone":     "555-111-2222",
+    "PatientChartNumber": "CHART-9999",
+    "PatientAccountNumber": "ACCT-8888",
+}
+
+_FAKE_SAFE = {
+    "ServiceDate":              "2025-03-15",
+    "ProcedureCode":            "99214",
+    "Modifiers":                "25",
+    "RenderingProviderName":    "Ehrin Irvin",
+    "FacilityName":             "JFM North",
+    "ChargeAmount":             "190.00",
+    "Units":                    "1",
+    "PrimaryInsuranceName":     "BlueCross",
+}
+
+
+class TestPiiRigour(unittest.TestCase):
+    """
+    Exhaustive PII protection tests.  Each test verifies that a specific
+    PII canary value is absent from the given output stage.
+    """
+
+    # ── Stage 1: _strip_pii_from_charge ─────────────────────────────────────
+
+    def test_realistic_pii_stripped_from_charge_dict(self):
+        charge = {**_FAKE_PII, **_FAKE_SAFE}
+        result = _strip_pii_from_charge(charge)
+        for field, value in _FAKE_PII.items():
+            self.assertNotIn(field, result,
+                             f"PII field '{field}' key survived stripping")
+            # Also check that the *value* didn't slip through under another key
+            self.assertNotIn(value, result.values(),
+                             f"PII value '{value}' (from '{field}') survived stripping")
+
+    def test_pii_values_not_in_output_values(self):
+        """Even if field names were renamed, PII values must not appear."""
+        charge = {**_FAKE_PII, **_FAKE_SAFE}
+        result = _strip_pii_from_charge(charge)
+        output_values = set(result.values())
+        for field, pii_val in _FAKE_PII.items():
+            self.assertNotIn(pii_val, output_values,
+                             f"PII value '{pii_val}' from field '{field}' found in output")
+
+    def test_all_known_pii_fields_blocked(self):
+        """Every field in TEBRA_PII_FIELDS must be absent from output."""
+        charge = {f: f"CANARY_{f}" for f in TEBRA_PII_FIELDS}
+        charge.update(_FAKE_SAFE)
+        result = _strip_pii_from_charge(charge)
+        for pii_field in TEBRA_PII_FIELDS:
+            self.assertNotIn(pii_field, result)
+            self.assertNotIn(f"CANARY_{pii_field}", result.values())
+
+    # ── Stage 2: _parse_charges_response (XML → dict) ───────────────────────
+
+    def _make_soap_xml(self, extra_fields: dict) -> str:
+        fields_xml = "".join(
+            f"<{k}>{v}</{k}>" for k, v in extra_fields.items()
+        )
+        return f"""<?xml version="1.0"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body>
+    <GetChargesResponse xmlns="http://www.kareo.com/api/schemas/">
+      <GetChargesResult>
+        <Charges>
+          <Charge>
+            <ServiceDate>2025-03-15</ServiceDate>
+            <ProcedureCode>99214</ProcedureCode>
+            <ChargeAmount>190.00</ChargeAmount>
+            <RenderingProviderName>Ehrin Irvin</RenderingProviderName>
+            {fields_xml}
+          </Charge>
+        </Charges>
+      </GetChargesResult>
+    </GetChargesResponse>
+  </soap:Body>
+</soap:Envelope>"""
+
+    def test_parse_response_strips_all_realistic_pii(self):
+        xml = self._make_soap_xml(_FAKE_PII)
+        charges = _parse_charges_response(xml)
+        self.assertEqual(len(charges), 1)
+        charge = charges[0]
+        for field, value in _FAKE_PII.items():
+            self.assertNotIn(field, charge,
+                             f"PII key '{field}' survived XML parsing")
+            self.assertNotIn(value, charge.values(),
+                             f"PII value '{value}' survived XML parsing")
+
+    def test_parse_multiple_charges_all_pii_stripped(self):
+        """PII stripping must hold for every charge in a multi-record response."""
+        charges_xml = ""
+        for i in range(5):
+            charges_xml += f"""
+          <Charge>
+            <ServiceDate>2025-0{i+1}-01</ServiceDate>
+            <ProcedureCode>9921{i+3}</ProcedureCode>
+            <PatientFirstName>Patient{i}</PatientFirstName>
+            <PatientSSN>111-{i:02d}-0000</PatientSSN>
+            <PatientDOB>198{i}-01-01</PatientDOB>
+            <ChargeAmount>100.00</ChargeAmount>
+            <RenderingProviderName>Anne Jenks</RenderingProviderName>
+          </Charge>"""
+        xml = f"""<?xml version="1.0"?>
+<soap:Envelope xmlns:soap="http://schemas.xmlsoap.org/soap/envelope/">
+  <soap:Body><GetChargesResponse xmlns="http://www.kareo.com/api/schemas/">
+    <GetChargesResult><Charges>{charges_xml}</Charges></GetChargesResult>
+  </GetChargesResponse></soap:Body>
+</soap:Envelope>"""
+        charges = _parse_charges_response(xml)
+        self.assertEqual(len(charges), 5)
+        for i, charge in enumerate(charges):
+            self.assertNotIn("PatientFirstName", charge)
+            self.assertNotIn("PatientSSN", charge)
+            self.assertNotIn("PatientDOB", charge)
+            # Verify the actual canary values are absent
+            all_values = set(charge.values())
+            self.assertNotIn(f"Patient{i}", all_values)
+            self.assertNotIn(f"111-{i:02d}-0000", all_values)
+
+    def test_unexpected_pii_field_names_blocked(self):
+        """
+        A field not in the known PII list but not in SAFE fields either must
+        be dropped (whitelist approach).
+        """
+        unexpected = {
+            "PatientMiddleName": "Marie",     # not in PII list but clearly PII
+            "PatientInsuranceID": "INS-123",  # not in PII list
+            "SomeFuturePatientField": "secret",
+        }
+        xml = self._make_soap_xml(unexpected)
+        charges = _parse_charges_response(xml)
+        charge = charges[0]
+        for field in unexpected:
+            self.assertNotIn(field, charge,
+                             f"Unknown field '{field}' should be blocked by whitelist")
+
+    # ── Stage 3: Final CSV output (canary test) ──────────────────────────────
+
+    @patch("requests.post")
+    def test_final_csv_output_contains_no_pii_column_names(self, mock_post):
+        """
+        PII canary: the bytes returned by pull_tebra_charges() and written
+        to the database must contain zero PII column names in any form.
+        """
+        xml = self._make_soap_xml(_FAKE_PII)
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.text = xml
+        mock_post.return_value = mock_response
+
+        with patch.dict(os.environ, {"TEBRAKEY": "test-key"}):
+            csv_bytes = pull_tebra_charges()
+
+        df = pd.read_csv(io.BytesIO(csv_bytes))
+        for pii_field in TEBRA_PII_FIELDS:
+            self.assertNotIn(pii_field, df.columns,
+                             f"PII column '{pii_field}' in final CSV output")
+
+    @patch("requests.post")
+    def test_final_csv_output_contains_no_pii_values(self, mock_post):
+        """
+        PII canary: the actual PII *values* must not appear anywhere in the
+        final CSV bytes — not in any column, not in any value.
+        """
+        xml = self._make_soap_xml(_FAKE_PII)
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.text = xml
+        mock_post.return_value = mock_response
+
+        with patch.dict(os.environ, {"TEBRAKEY": "test-key"}):
+            csv_bytes = pull_tebra_charges()
+
+        csv_text = csv_bytes.decode("utf-8")
+        for field, pii_value in _FAKE_PII.items():
+            self.assertNotIn(pii_value, csv_text,
+                             f"PII value '{pii_value}' (field '{field}') found in CSV bytes")
+
+    # ── Stage 4: Log output cleanliness ─────────────────────────────────────
+
+    @patch("requests.post")
+    def test_log_output_contains_no_pii(self, mock_post):
+        """
+        No PII canary value should appear in any log record emitted during
+        pull_tebra_charges().
+        """
+        xml = self._make_soap_xml(_FAKE_PII)
+        mock_response = MagicMock()
+        mock_response.raise_for_status = MagicMock()
+        mock_response.text = xml
+        mock_post.return_value = mock_response
+
+        import logging
+        log_records = []
+
+        class _Capture(logging.Handler):
+            def emit(self, record):
+                log_records.append(self.format(record))
+
+        handler = _Capture()
+        handler.setFormatter(logging.Formatter("%(message)s"))
+        ingestion_logger = logging.getLogger("data_ingestion")
+        ingestion_logger.addHandler(handler)
+        ingestion_logger.setLevel(logging.DEBUG)
+
+        try:
+            with patch.dict(os.environ, {"TEBRAKEY": "test-key"}):
+                pull_tebra_charges()
+        finally:
+            ingestion_logger.removeHandler(handler)
+
+        combined_logs = "\n".join(log_records)
+        for field, pii_value in _FAKE_PII.items():
+            self.assertNotIn(pii_value, combined_logs,
+                             f"PII value '{pii_value}' (field '{field}') found in log output")
+
+    # ── Stage 5: PII_FIELDS completeness ────────────────────────────────────
+
+    def test_pii_fields_constant_covers_all_fake_pii(self):
+        """Every key in _FAKE_PII must be present in TEBRA_PII_FIELDS."""
+        for field in _FAKE_PII:
+            self.assertIn(field, TEBRA_PII_FIELDS,
+                          f"'{field}' is a known PII field but not in TEBRA_PII_FIELDS blocklist")
+
+    def test_safe_fields_and_pii_fields_are_disjoint(self):
+        """No field can be in both TEBRA_SAFE_FIELDS and TEBRA_PII_FIELDS."""
+        overlap = TEBRA_SAFE_FIELDS & TEBRA_PII_FIELDS
+        self.assertEqual(overlap, set(),
+                         f"Fields in both safe and PII lists: {overlap}")
+
+    def test_whitelist_rejects_all_unlisted_fields(self):
+        """
+        Anything not explicitly in TEBRA_SAFE_FIELDS must be dropped,
+        including plausible future PII field names.
+        """
+        plausible_future_pii = [
+            "PatientMiddleName", "PatientNickname", "PatientInsuranceID",
+            "PatientMemberID", "PatientGroupNumber", "ResponsiblePartyName",
+            "ResponsiblePartyDOB", "SubscriberName", "SubscriberDOB",
+        ]
+        charge = {f: f"secret_{f}" for f in plausible_future_pii}
+        charge.update(_FAKE_SAFE)
+        result = _strip_pii_from_charge(charge)
+        for field in plausible_future_pii:
+            self.assertNotIn(field, result,
+                             f"Unlisted field '{field}' should be blocked by whitelist")
+
+
+# ── Deduplication Tests ───────────────────────────────────────────────────────
+
+class TestDeduplication(unittest.TestCase):
+    """
+    Duplicate prevention: running ingestion twice with the same data must not
+    produce duplicate rows in the stored CSV.
+    """
+
+    def _make_pc_df(self, rows: list[dict]) -> pd.DataFrame:
+        base = {
+            "Date Of Service": "2025-03-01",
+            "Rendering Provider": "Anne Jenks",
+            "Procedure Codes with Modifiers": "99213",
+            "Service Charge Amount": "150.00",
+            "Units": "1",
+        }
+        records = [{**base, **r} for r in rows]
+        return pd.DataFrame(records)
+
+    def test_identical_rows_deduplicated(self):
+        df = self._make_pc_df([{}])
+        result = _dedup_charges(df, df.copy())
+        self.assertEqual(len(result), 1)
+
+    def test_no_existing_data_returns_new(self):
+        new_df = self._make_pc_df([{}, {"Date Of Service": "2025-03-02"}])
+        result = _dedup_charges(new_df, pd.DataFrame())
+        self.assertEqual(len(result), 2)
+
+    def test_no_new_data_returns_existing(self):
+        existing = self._make_pc_df([{}, {"Date Of Service": "2025-03-02"}])
+        result = _dedup_charges(pd.DataFrame(), existing)
+        self.assertEqual(len(result), 2)
+
+    def test_disjoint_rows_all_retained(self):
+        new_df = self._make_pc_df([{"Date Of Service": "2025-03-03"}])
+        existing = self._make_pc_df([{"Date Of Service": "2025-03-04"}])
+        result = _dedup_charges(new_df, existing)
+        self.assertEqual(len(result), 2)
+
+    def test_partial_overlap_correct_count(self):
+        """3 new + 3 existing where 1 overlaps → 5 unique rows."""
+        new_df = self._make_pc_df([
+            {"Date Of Service": "2025-03-01"},  # overlap
+            {"Date Of Service": "2025-03-02"},  # new
+            {"Date Of Service": "2025-03-03"},  # new
+        ])
+        existing = self._make_pc_df([
+            {"Date Of Service": "2025-03-01"},  # overlap
+            {"Date Of Service": "2025-03-04"},  # existing-only
+            {"Date Of Service": "2025-03-05"},  # existing-only
+        ])
+        result = _dedup_charges(new_df, existing)
+        self.assertEqual(len(result), 5)
+
+    def test_new_version_of_row_replaces_existing(self):
+        """
+        If the same date+provider+CPT+units appears with a different charge
+        amount, the new version (from new_df) should win.
+        """
+        new_df = self._make_pc_df([{"Service Charge Amount": "200.00"}])
+        existing = self._make_pc_df([{"Service Charge Amount": "150.00"}])
+        # Both have same date/provider/CPT/units but different charge amount
+        # so they are NOT duplicates under PC_DEDUP_KEYS — both are kept
+        result = _dedup_charges(new_df, existing)
+        self.assertEqual(len(result), 2)
+
+    def test_same_date_different_cpt_both_kept(self):
+        existing = self._make_pc_df([{"Procedure Codes with Modifiers": "99213"}])
+        new_df = self._make_pc_df([{"Procedure Codes with Modifiers": "99214"}])
+        result = _dedup_charges(new_df, existing)
+        self.assertEqual(len(result), 2)
+
+    def test_same_cpt_different_date_both_kept(self):
+        existing = self._make_pc_df([{"Date Of Service": "2025-03-01"}])
+        new_df = self._make_pc_df([{"Date Of Service": "2025-03-02"}])
+        result = _dedup_charges(new_df, existing)
+        self.assertEqual(len(result), 2)
+
+    def test_same_cpt_different_provider_both_kept(self):
+        existing = self._make_pc_df([{"Rendering Provider": "Anne Jenks"}])
+        new_df = self._make_pc_df([{"Rendering Provider": "Ehrin Irvin"}])
+        result = _dedup_charges(new_df, existing)
+        self.assertEqual(len(result), 2)
+
+    def test_ingestion_twice_does_not_double_rows(self):
+        """
+        Simulate running the full pipeline twice with the same data.
+        Total row count must equal the number of unique charges, not 2×.
+        """
+        pc_csv = (
+            b"Date Of Service,Rendering Provider,Procedure Codes with Modifiers,"
+            b"Service Charge Amount,Units\n"
+            b"2025-03-01,Anne Jenks,99213,150.00,1\n"
+            b"2025-03-02,Anne Jenks,99214,190.00,1\n"
+            b"2025-03-03,Ehrin Irvin,99213,150.00,1\n"
+        )
+
+        stored = {}
+
+        def fake_store(filename, csv_bytes):
+            stored[filename] = csv_bytes
+
+        def fake_read_existing(filename):
+            if filename in stored:
+                return pd.read_csv(io.BytesIO(stored[filename]))
+            return pd.DataFrame()
+
+        with patch("data_ingestion.pull_tebra_charges", return_value=pc_csv), \
+             patch("data_ingestion.pull_google_sheets_va_data",
+                   return_value=b"Date of Service,Provider\n"), \
+             patch("data_ingestion.store_csv_to_db", side_effect=fake_store), \
+             patch("data_ingestion._read_existing_csv_from_db",
+                   side_effect=fake_read_existing):
+            # First ingestion
+            run_ingestion_pipeline()
+            first_count = len(pd.read_csv(io.BytesIO(stored["Charges Export.csv"])))
+
+            # Second ingestion with identical data
+            run_ingestion_pipeline()
+            second_count = len(pd.read_csv(io.BytesIO(stored["Charges Export.csv"])))
+
+        self.assertEqual(first_count, 3, "First run should have 3 rows")
+        self.assertEqual(second_count, 3, "Second run must not duplicate rows")
+
+    def test_new_data_added_on_second_ingestion(self):
+        """Second run with additional charges adds only the new ones."""
+        first_csv = (
+            b"Date Of Service,Rendering Provider,Procedure Codes with Modifiers,"
+            b"Service Charge Amount,Units\n"
+            b"2025-03-01,Anne Jenks,99213,150.00,1\n"
+        )
+        second_csv = (
+            b"Date Of Service,Rendering Provider,Procedure Codes with Modifiers,"
+            b"Service Charge Amount,Units\n"
+            b"2025-03-01,Anne Jenks,99213,150.00,1\n"   # duplicate
+            b"2025-03-02,Anne Jenks,99214,190.00,1\n"   # new
+        )
+
+        stored = {}
+        pull_results = iter([first_csv, second_csv])
+
+        def fake_store(filename, csv_bytes):
+            stored[filename] = csv_bytes
+
+        def fake_read_existing(filename):
+            if filename in stored:
+                return pd.read_csv(io.BytesIO(stored[filename]))
+            return pd.DataFrame()
+
+        with patch("data_ingestion.pull_tebra_charges", side_effect=pull_results), \
+             patch("data_ingestion.pull_google_sheets_va_data",
+                   return_value=b"Date of Service,Provider\n"), \
+             patch("data_ingestion.store_csv_to_db", side_effect=fake_store), \
+             patch("data_ingestion._read_existing_csv_from_db",
+                   side_effect=fake_read_existing):
+            run_ingestion_pipeline(sources=["pc"])
+            count_after_first = len(pd.read_csv(io.BytesIO(stored["Charges Export.csv"])))
+
+            run_ingestion_pipeline(sources=["pc"])
+            count_after_second = len(pd.read_csv(io.BytesIO(stored["Charges Export.csv"])))
+
+        self.assertEqual(count_after_first, 1)
+        self.assertEqual(count_after_second, 2, "Only the genuinely new row should be added")
+
+
+if __name__ == "__main__":
+    unittest.main()

--- a/requirements.txt
+++ b/requirements.txt
@@ -9,3 +9,5 @@ numpy
 scipy
 matplotlib
 statsmodels
+google-api-python-client>=2.0  # Google Sheets API for VA C&P data ingestion
+google-auth>=2.0               # Service account authentication for Google APIs

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -313,6 +313,7 @@
         <div class="admin-tabs">
             <button class="tab-button active" onclick="openTab('section-reports', this)">Reports</button>
             {% if current_user.role == 'Owner' %}
+            <button class="tab-button" onclick="openTab('section-owner-analytics', this); initOwnerAnalytics();">Owner Analytics</button>
             <button class="tab-button" onclick="openTab('section-upload', this)">Upload Data</button>
             {% endif %}
             {% if current_user.role in ['Owner', 'Admin'] %}
@@ -370,6 +371,96 @@
                 {% endif %}
             </div>
         </div>
+
+        <!-- Owner Analytics Section -->
+        {% if current_user.role == 'Owner' %}
+        <div id="section-owner-analytics" class="tab-content" style="display: none;">
+
+            <!-- Loading state -->
+            <div id="oa-loading" style="text-align: center; padding: 3rem 1rem;">
+                <p style="color: var(--text-light); font-size: 1rem;">Loading analytics data...</p>
+            </div>
+
+            <!-- Error state -->
+            <div id="oa-error" style="display: none;">
+                <div class="admin-panel">
+                    <p style="color: #991b1b;">&#x26A0; Failed to load analytics. Ensure CSV files have been uploaded via the Upload Data tab.</p>
+                </div>
+            </div>
+
+            <!-- Content (shown after data loads) -->
+            <div id="oa-content" style="display: none;">
+
+                <!-- Quick Nav -->
+                <div class="admin-panel" style="padding: 0.85rem 1.5rem; margin-bottom: 1.25rem;">
+                    <div style="display: flex; gap: 1.25rem; flex-wrap: wrap; align-items: center;">
+                        <span style="font-size: 0.8rem; font-weight: 700; color: var(--text-light); text-transform: uppercase; letter-spacing: 0.05em;">Jump to:</span>
+                        <a href="#oa-scorecards" style="color: var(--primary-color); font-weight: 600; font-size: 0.9rem; text-decoration: none;">Scorecards</a>
+                        <a href="#oa-trends" style="color: var(--primary-color); font-weight: 600; font-size: 0.9rem; text-decoration: none;">Trends</a>
+                        <a href="#oa-breakeven" style="color: var(--primary-color); font-weight: 600; font-size: 0.9rem; text-decoration: none;">Breakeven</a>
+                        <a href="#oa-monthly" style="color: var(--primary-color); font-weight: 600; font-size: 0.9rem; text-decoration: none;">Monthly</a>
+                        <a href="#oa-recommendations" style="color: var(--primary-color); font-weight: 600; font-size: 0.9rem; text-decoration: none;">Recommendations</a>
+                        <button onclick="refreshOwnerAnalytics()" style="margin-left: auto; background: none; border: 1px solid #d1d5db; border-radius: 6px; padding: 4px 12px; font-size: 0.8rem; cursor: pointer; color: var(--text-light);">&#x21BB; Refresh</button>
+                    </div>
+                </div>
+
+                <!-- 1. Provider Scorecards -->
+                <div id="oa-scorecards" class="admin-panel">
+                    <h2>&#x1F464; Provider Scorecards</h2>
+                    <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1.25rem;">Per-provider summary since Oct 1, 2025. Trend is based on last 4 weeks vs prior 4 weeks.</p>
+                    <div id="scorecard-grid" style="display: grid; grid-template-columns: 1fr 1fr; gap: 1rem;"></div>
+                </div>
+
+                <!-- 2. Trend Analysis -->
+                <div id="oa-trends" class="admin-panel">
+                    <h2>&#x1F4C8; Trend Analysis</h2>
+                    <p style="font-weight: 600; font-size: 0.85rem; color: var(--text-light); margin-bottom: 0.5rem; text-transform: uppercase; letter-spacing: 0.04em;">Rolling 4-Week Average by Provider</p>
+                    <div style="position: relative; height: 300px;">
+                        <canvas id="chart-rolling4"></canvas>
+                    </div>
+                    <hr style="border: 0; border-top: 1px solid #f1f1f1; margin: 1.5rem 0;">
+                    <p style="font-weight: 600; font-size: 0.85rem; color: var(--text-light); margin-bottom: 0.5rem; text-transform: uppercase; letter-spacing: 0.04em;">Week-over-Week % Change (Company Total)</p>
+                    <div style="position: relative; height: 220px;">
+                        <canvas id="chart-wow"></canvas>
+                    </div>
+                    <hr style="border: 0; border-top: 1px solid #f1f1f1; margin: 1.5rem 0;">
+                    <p style="font-weight: 600; font-size: 0.85rem; color: var(--text-light); margin-bottom: 0.5rem; text-transform: uppercase; letter-spacing: 0.04em;">Cumulative RVU Race</p>
+                    <div style="position: relative; height: 300px;">
+                        <canvas id="chart-cumulative"></canvas>
+                    </div>
+                </div>
+
+                <!-- 3. Breakeven Analysis -->
+                <div id="oa-breakeven" class="admin-panel">
+                    <h2>&#x1F3AF; Breakeven Analysis</h2>
+                    <p style="font-weight: 600; font-size: 0.85rem; color: var(--text-light); margin-bottom: 0.5rem; text-transform: uppercase; letter-spacing: 0.04em;">Company-Wide Distance from Breakeven (196 RVUs/week)</p>
+                    <div style="position: relative; height: 260px;">
+                        <canvas id="chart-co-breakeven"></canvas>
+                    </div>
+                    <hr style="border: 0; border-top: 1px solid #f1f1f1; margin: 1.5rem 0;">
+                    <p style="font-weight: 600; font-size: 0.85rem; color: var(--text-light); margin-bottom: 0.75rem; text-transform: uppercase; letter-spacing: 0.04em;">Provider Benchmark Summary</p>
+                    <div id="breakeven-table"></div>
+                </div>
+
+                <!-- 4. Monthly Overview -->
+                <div id="oa-monthly" class="admin-panel">
+                    <h2>&#x1F4C5; Monthly Overview</h2>
+                    <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">Stacked monthly RVU totals by provider vs company breakeven and industry standard targets.</p>
+                    <div style="position: relative; height: 340px;">
+                        <canvas id="chart-monthly"></canvas>
+                    </div>
+                </div>
+
+                <!-- 5. Recommendations -->
+                <div id="oa-recommendations" class="admin-panel">
+                    <h2>&#x1F4A1; Recommendations</h2>
+                    <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1rem;">Auto-generated insights based on current production data.</p>
+                    <div id="recommendations-list"></div>
+                </div>
+
+            </div>
+        </div>
+        {% endif %}
 
         <!-- Conditional Banner Management -->
         {% if current_user.role in ['Owner', 'Admin'] %}
@@ -446,9 +537,7 @@
 
                 <hr style="border: 0; border-top: 1px solid #f1f1f1; margin: 2rem 0;">
                 <h2>👑 Owner Only Features</h2>
-                <p style="color: var(--text-light); font-size: 0.95rem;">Coming soon: Manage users, export full system
-                    logs,
-                    and view revenue analytics.</p>
+                <p style="color: var(--text-light); font-size: 0.95rem;">Owner Analytics are available in the <strong>Owner Analytics</strong> tab — including Provider Scorecards, Trend Analysis, Breakeven Analysis, Monthly Overview, and Recommendations. Coming soon: user management and system logs.</p>
             </div>
         </div>
         {% endif %}
@@ -493,6 +582,7 @@
         ⚠️ Your session will expire soon due to inactivity.
     </div>
 
+    <script src="https://cdn.jsdelivr.net/npm/chart.js@4.4.0/dist/chart.umd.min.js"></script>
     <script>
         // --- Tabs Logic ---
         function openTab(tabId, element) {
@@ -559,6 +649,272 @@
         });
 
         resetTimers();
+
+        // -------------------------------------------------------
+        // Owner Analytics
+        // -------------------------------------------------------
+        let _oaLoaded = false;
+        const _chartInstances = {};
+
+        function initOwnerAnalytics() {
+            if (!_oaLoaded) {
+                _oaLoaded = true;
+                _fetchAnalytics();
+            }
+        }
+
+        function refreshOwnerAnalytics() {
+            _oaLoaded = false;
+            document.getElementById('oa-content').style.display = 'none';
+            document.getElementById('oa-error').style.display = 'none';
+            document.getElementById('oa-loading').style.display = 'block';
+            initOwnerAnalytics();
+        }
+
+        async function _fetchAnalytics() {
+            const loading = document.getElementById('oa-loading');
+            const error = document.getElementById('oa-error');
+            const content = document.getElementById('oa-content');
+            if (!loading) return;
+            try {
+                const resp = await fetch('/admin/reports/owner_analytics');
+                if (!resp.ok) throw new Error('HTTP ' + resp.status);
+                const data = await resp.json();
+                if (data.error) throw new Error(data.error);
+                loading.style.display = 'none';
+                content.style.display = 'block';
+                _renderScorecards(data.scorecards);
+                _renderTrends(data.trends);
+                _renderBreakeven(data.breakeven);
+                _renderMonthly(data.monthly);
+                _renderRecommendations(data.recommendations);
+            } catch (e) {
+                if (loading) loading.style.display = 'none';
+                if (error) error.style.display = 'block';
+                console.error('Owner analytics error:', e);
+            }
+        }
+
+        function _destroyChart(id) {
+            if (_chartInstances[id]) { _chartInstances[id].destroy(); delete _chartInstances[id]; }
+        }
+
+        function _baseOptions(yLabel, beginAtZero) {
+            return {
+                responsive: true,
+                maintainAspectRatio: false,
+                plugins: {
+                    legend: { position: 'bottom', labels: { boxWidth: 12, padding: 12, font: { size: 11 } } }
+                },
+                scales: {
+                    x: { ticks: { maxRotation: 45, font: { size: 10 } }, grid: { display: false } },
+                    y: {
+                        title: { display: !!yLabel, text: yLabel || '', font: { size: 11 } },
+                        grid: { color: '#f3f4f6' },
+                        beginAtZero: !!beginAtZero
+                    }
+                }
+            };
+        }
+
+        function _statCell(label, value) {
+            return `<div style="text-align:center;padding:0.4rem;background:#f9fafb;border-radius:4px;">
+                <div style="font-size:0.95rem;font-weight:700;color:#111827;">${value}</div>
+                <div style="font-size:0.7rem;color:#6b7280;margin-top:2px;">${label}</div>
+            </div>`;
+        }
+
+        function _renderScorecards(scorecards) {
+            const grid = document.getElementById('scorecard-grid');
+            if (!grid || !scorecards) return;
+            grid.innerHTML = '';
+            const icons = { Improving: '&#x2191;', Stable: '&#x2192;', Declining: '&#x2193;' };
+            const tColor = { Improving: '#166534', Stable: '#1e40af', Declining: '#991b1b' };
+            const tBg = { Improving: '#f0fdf4', Stable: '#eff6ff', Declining: '#fef2f2' };
+            for (const [name, s] of Object.entries(scorecards)) {
+                const card = document.createElement('div');
+                card.style.cssText = 'border:1px solid #e5e7eb;border-radius:8px;padding:1rem;';
+                card.innerHTML = `
+                    <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:0.75rem;">
+                        <div style="display:flex;align-items:center;gap:0.5rem;">
+                            <span style="width:12px;height:12px;border-radius:50%;background:${s.color};display:inline-block;flex-shrink:0;"></span>
+                            <strong style="font-size:0.95rem;">${name}</strong>
+                        </div>
+                        <span style="font-size:0.75rem;font-weight:600;padding:2px 8px;border-radius:999px;background:${tBg[s.trend]};color:${tColor[s.trend]};white-space:nowrap;">
+                            ${icons[s.trend]} ${s.trend}
+                        </span>
+                    </div>
+                    <div style="display:grid;grid-template-columns:1fr 1fr 1fr;gap:0.4rem;">
+                        ${_statCell('Total RVUs', s.total_rvus)}
+                        ${_statCell('Avg / Week', s.avg_weekly)}
+                        ${_statCell('Std Dev', s.std_dev)}
+                        ${_statCell('Breakeven Rate', s.breakeven_hit_rate + '%')}
+                        ${_statCell('Industry Rate', s.industry_hit_rate + '%')}
+                        ${_statCell('Weeks Tracked', s.weeks_count)}
+                        ${_statCell('Best Week', s.best_week)}
+                        ${_statCell('Worst Week', s.worst_week)}
+                        ${_statCell('Trend \u0394', (s.trend_pct > 0 ? '+' : '') + s.trend_pct + '%')}
+                    </div>`;
+                grid.appendChild(card);
+            }
+        }
+
+        function _renderTrends(trends) {
+            if (!trends || !trends.weeks) return;
+            const { weeks, providers, company, benchmarks: b } = trends;
+
+            // Rolling 4-week average
+            _destroyChart('chart-rolling4');
+            const benchDatasets = [
+                { label: 'Breakeven (49)', data: weeks.map(() => b.ind_breakeven), borderColor: '#ef4444', borderDash: [6, 3], borderWidth: 1.5, pointRadius: 0, fill: false },
+                { label: 'Industry (82)', data: weeks.map(() => b.ind_industry), borderColor: '#f97316', borderDash: [6, 3], borderWidth: 1.5, pointRadius: 0, fill: false }
+            ];
+            _chartInstances['chart-rolling4'] = new Chart(
+                document.getElementById('chart-rolling4').getContext('2d'),
+                {
+                    type: 'line',
+                    data: {
+                        labels: weeks,
+                        datasets: Object.entries(providers).map(([name, d]) => ({
+                            label: name, data: d.rolling4, borderColor: d.color,
+                            backgroundColor: d.color + '18', borderWidth: 2.5,
+                            pointRadius: 3, tension: 0.3, fill: false
+                        })).concat(benchDatasets)
+                    },
+                    options: _baseOptions('RVUs', false)
+                }
+            );
+
+            // WoW % Change
+            _destroyChart('chart-wow');
+            const wowColors = company.wow_pct.map(v => v >= 0 ? '#27ae60bb' : '#e74c3cbb');
+            const wowOpts = _baseOptions('%', false);
+            wowOpts.plugins.legend = { display: false };
+            _chartInstances['chart-wow'] = new Chart(
+                document.getElementById('chart-wow').getContext('2d'),
+                {
+                    type: 'bar',
+                    data: {
+                        labels: weeks,
+                        datasets: [{ label: 'WoW % Change', data: company.wow_pct, backgroundColor: wowColors, borderWidth: 0 }]
+                    },
+                    options: wowOpts
+                }
+            );
+
+            // Cumulative Race
+            _destroyChart('chart-cumulative');
+            _chartInstances['chart-cumulative'] = new Chart(
+                document.getElementById('chart-cumulative').getContext('2d'),
+                {
+                    type: 'line',
+                    data: {
+                        labels: weeks,
+                        datasets: Object.entries(providers).map(([name, d]) => ({
+                            label: name, data: d.cumulative, borderColor: d.color,
+                            borderWidth: 2.5, pointRadius: 2, tension: 0.2, fill: false
+                        }))
+                    },
+                    options: _baseOptions('Cumulative RVUs', false)
+                }
+            );
+        }
+
+        function _renderBreakeven(breakeven) {
+            if (!breakeven || !breakeven.weeks) return;
+            const { weeks, company_distances: dists, providers } = breakeven;
+
+            // Company distance bar
+            _destroyChart('chart-co-breakeven');
+            _chartInstances['chart-co-breakeven'] = new Chart(
+                document.getElementById('chart-co-breakeven').getContext('2d'),
+                {
+                    type: 'bar',
+                    data: {
+                        labels: weeks,
+                        datasets: [{
+                            label: 'RVUs vs Breakeven (196)',
+                            data: dists,
+                            backgroundColor: dists.map(v => v >= 0 ? '#27ae6088' : '#e74c3c88'),
+                            borderColor: dists.map(v => v >= 0 ? '#27ae60' : '#e74c3c'),
+                            borderWidth: 1
+                        }]
+                    },
+                    options: (() => {
+                        const o = _baseOptions('RVUs from Breakeven', false);
+                        o.plugins.legend = { display: false };
+                        return o;
+                    })()
+                }
+            );
+
+            // Provider hit rate table
+            const tableDiv = document.getElementById('breakeven-table');
+            if (!tableDiv) return;
+            const rows = Object.entries(providers).map(([name, d]) => `
+                <tr style="border-bottom:1px solid #f3f4f6;">
+                    <td style="padding:0.5rem 0.75rem;display:flex;align-items:center;gap:0.5rem;">
+                        <span style="width:10px;height:10px;border-radius:50%;background:${d.color};display:inline-block;flex-shrink:0;"></span>${name}
+                    </td>
+                    <td style="padding:0.5rem 0.75rem;text-align:center;font-weight:600;">${d.avg_weekly}</td>
+                    <td style="padding:0.5rem 0.75rem;text-align:center;">
+                        <span style="color:${d.avg_weekly >= 49 ? '#166534' : '#991b1b'};font-weight:600;">${d.hit_rate}%</span>
+                    </td>
+                    <td style="padding:0.5rem 0.75rem;text-align:center;">
+                        <span style="color:${d.industry_hit_rate >= 50 ? '#166534' : '#991b1b'};font-weight:600;">${d.industry_hit_rate}%</span>
+                    </td>
+                </tr>`).join('');
+            tableDiv.innerHTML = `
+                <table style="width:100%;border-collapse:collapse;font-size:0.9rem;">
+                    <thead>
+                        <tr style="border-bottom:2px solid #e5e7eb;">
+                            <th style="padding:0.5rem 0.75rem;text-align:left;font-size:0.75rem;color:#6b7280;text-transform:uppercase;letter-spacing:0.05em;">Provider</th>
+                            <th style="padding:0.5rem 0.75rem;text-align:center;font-size:0.75rem;color:#6b7280;text-transform:uppercase;letter-spacing:0.05em;">Avg/Week</th>
+                            <th style="padding:0.5rem 0.75rem;text-align:center;font-size:0.75rem;color:#6b7280;text-transform:uppercase;letter-spacing:0.05em;">Breakeven Rate (&ge;49)</th>
+                            <th style="padding:0.5rem 0.75rem;text-align:center;font-size:0.75rem;color:#6b7280;text-transform:uppercase;letter-spacing:0.05em;">Industry Rate (&ge;82)</th>
+                        </tr>
+                    </thead>
+                    <tbody>${rows}</tbody>
+                </table>`;
+        }
+
+        function _renderMonthly(monthly) {
+            if (!monthly || !monthly.months) return;
+            _destroyChart('chart-monthly');
+            const providerDatasets = Object.entries(monthly.providers).map(([name, d]) => ({
+                type: 'bar', label: name, data: d.values,
+                backgroundColor: d.color + 'bb', borderColor: d.color, borderWidth: 1, stack: 'providers'
+            }));
+            const lineDatasets = [
+                { type: 'line', label: 'Breakeven Target', data: monthly.company_breakeven, borderColor: '#ef4444', borderDash: [6, 3], borderWidth: 2, pointRadius: 3, fill: false },
+                { type: 'line', label: 'Industry Standard', data: monthly.company_industry, borderColor: '#f97316', borderDash: [6, 3], borderWidth: 2, pointRadius: 3, fill: false }
+            ];
+            _chartInstances['chart-monthly'] = new Chart(
+                document.getElementById('chart-monthly').getContext('2d'),
+                {
+                    type: 'bar',
+                    data: { labels: monthly.months, datasets: [...providerDatasets, ...lineDatasets] },
+                    options: _baseOptions('Total RVUs', true)
+                }
+            );
+        }
+
+        function _renderRecommendations(recs) {
+            const div = document.getElementById('recommendations-list');
+            if (!div || !recs) return;
+            const styles = {
+                success: { bg: '#f0fdf4', border: '#bbf7d0', color: '#166534', icon: '&#x2705;' },
+                warning: { bg: '#fefce8', border: '#fde68a', color: '#854d0e', icon: '&#x26A0;&#xFE0F;' },
+                alert:   { bg: '#fef2f2', border: '#fecaca', color: '#991b1b', icon: '&#x1F534;' },
+                info:    { bg: '#eff6ff', border: '#bfdbfe', color: '#1e40af', icon: '&#x2139;&#xFE0F;' }
+            };
+            div.innerHTML = recs.map(r => {
+                const s = styles[r.type] || styles.info;
+                return `<div style="background:${s.bg};border:1px solid ${s.border};color:${s.color};padding:0.7rem 1rem;border-radius:6px;margin-bottom:0.5rem;font-size:0.9rem;display:flex;gap:0.6rem;align-items:flex-start;">
+                    <span style="flex-shrink:0;font-size:1rem;">${s.icon}</span><span>${r.text}</span>
+                </div>`;
+            }).join('');
+        }
     </script>
 </body>
 

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -313,6 +313,7 @@
         <div class="admin-tabs">
             <button class="tab-button active" onclick="openTab('section-reports', this)">Reports</button>
             {% if current_user.role == 'Owner' %}
+            <button class="tab-button" onclick="openTab('section-pull-data', this)">Pull Data</button>
             <button class="tab-button" onclick="openTab('section-owner-analytics', this); initOwnerAnalytics();">Owner Analytics</button>
             <button class="tab-button" onclick="openTab('section-upload', this)">Upload Data</button>
             {% endif %}
@@ -503,6 +504,49 @@
         </div>
         {% endif %}
 
+        <!-- Pull Data Tab (Owner only) -->
+        {% if current_user.role == 'Owner' %}
+        <div id="section-pull-data" class="tab-content" style="display: none;">
+            <div class="admin-panel">
+                <h2>👑 Pull Data from Sources</h2>
+                <p style="color: var(--text-light); font-size: 0.9rem; margin-bottom: 1.5rem;">
+                    Automatically pull the latest data from Google Sheets (VA C&amp;P exams) and
+                    Tebra (primary care charges). New records are merged with existing data —
+                    duplicates are automatically skipped.
+                </p>
+
+                <div style="display: flex; gap: 1rem; flex-wrap: wrap; margin-bottom: 1.5rem;">
+                    <button id="btn-pull-all" class="button" onclick="triggerPullData('all')">
+                        Pull All Sources
+                    </button>
+                    <button id="btn-pull-va" class="button" style="background: #2ecc71;" onclick="triggerPullData('va')">
+                        Pull VA Only (Google Sheets)
+                    </button>
+                    <button id="btn-pull-pc" class="button" style="background: #f39c12;" onclick="triggerPullData('pc')">
+                        Pull Primary Care Only (Tebra)
+                    </button>
+                </div>
+
+                <!-- Status area -->
+                <div id="pull-data-status" style="display: none;">
+                    <div id="pull-data-loading" style="display: none; padding: 1rem; background: #eff6ff; border: 1px solid #bfdbfe; border-radius: var(--radius-md); color: #1e40af; font-size: 0.9rem;">
+                        ⏳ Pulling data from external sources&hellip; This may take up to 30 seconds.
+                    </div>
+                    <div id="pull-data-results" style="display: none;"></div>
+                </div>
+
+                <hr style="border: 0; border-top: 1px solid #f1f1f1; margin: 2rem 0;">
+                <h3 style="font-size: 1rem; color: var(--text-light); font-weight: 600; margin-bottom: 0.5rem;">
+                    Requirements
+                </h3>
+                <ul style="color: var(--text-light); font-size: 0.85rem; line-height: 1.8; margin: 0; padding-left: 1.25rem;">
+                    <li><strong>VA data:</strong> Heroku config var <code>GOOGLE_SHEETS_CREDENTIALS</code> must be set to the GCP service account JSON</li>
+                    <li><strong>Primary Care data:</strong> Heroku config var <code>TEBRAKEY</code> must be set to the Tebra customer API key</li>
+                </ul>
+            </div>
+        </div>
+        {% endif %}
+
         <!-- Conditional Owner Functionality -->
         {% if current_user.role == 'Owner' %}
         <div id="section-upload" class="tab-content" style="display: none;">
@@ -603,6 +647,65 @@
             if (element) {
                 element.classList.add('active');
             }
+        }
+
+        // --- Pull Data ---
+        function triggerPullData(source) {
+            const statusDiv = document.getElementById('pull-data-status');
+            const loadingDiv = document.getElementById('pull-data-loading');
+            const resultsDiv = document.getElementById('pull-data-results');
+            const buttons = ['btn-pull-all', 'btn-pull-va', 'btn-pull-pc']
+                .map(id => document.getElementById(id));
+
+            // Show loading, hide previous results
+            statusDiv.style.display = 'block';
+            loadingDiv.style.display = 'block';
+            resultsDiv.style.display = 'none';
+            resultsDiv.innerHTML = '';
+            buttons.forEach(b => { if (b) b.disabled = true; });
+
+            fetch("{{ url_for('admin_pull_data') }}", {
+                method: 'POST',
+                headers: { 'Content-Type': 'application/json' },
+                body: JSON.stringify({ source: source })
+            })
+            .then(res => res.json())
+            .then(data => {
+                loadingDiv.style.display = 'none';
+                resultsDiv.style.display = 'block';
+
+                if (data.status === 'ok') {
+                    let html = '<div style="padding:1rem;background:#f0fdf4;border:1px solid #bbf7d0;border-radius:var(--radius-md);font-size:0.9rem;color:#166534;">';
+                    html += '<strong>Data pull complete.</strong><ul style="margin:0.5rem 0 0 1.25rem;line-height:1.9;">';
+                    const r = data.results || {};
+                    if (r.va) {
+                        if (r.va.status === 'ok') {
+                            html += `<li>VA: ${r.va.rows} rows stored</li>`;
+                        } else {
+                            html += `<li style="color:#991b1b;">VA failed: ${r.va.error}</li>`;
+                        }
+                    }
+                    if (r.pc) {
+                        if (r.pc.status === 'ok') {
+                            html += `<li>Primary Care: ${r.pc.rows} total rows (${r.pc.new_rows} new)</li>`;
+                        } else {
+                            html += `<li style="color:#991b1b;">Primary Care failed: ${r.pc.error}</li>`;
+                        }
+                    }
+                    html += '</ul></div>';
+                    resultsDiv.innerHTML = html;
+                } else {
+                    resultsDiv.innerHTML = `<div style="padding:1rem;background:#fef2f2;border:1px solid #fecaca;border-radius:var(--radius-md);font-size:0.9rem;color:#991b1b;"><strong>Error:</strong> ${data.error || 'Unknown error'}</div>`;
+                }
+            })
+            .catch(err => {
+                loadingDiv.style.display = 'none';
+                resultsDiv.style.display = 'block';
+                resultsDiv.innerHTML = `<div style="padding:1rem;background:#fef2f2;border:1px solid #fecaca;border-radius:var(--radius-md);font-size:0.9rem;color:#991b1b;"><strong>Request failed:</strong> ${err.message}</div>`;
+            })
+            .finally(() => {
+                buttons.forEach(b => { if (b) b.disabled = false; });
+            });
         }
 
         // --- Banner preview ---


### PR DESCRIPTION
… recommendations

- New data/owner_analytics.py: backend analytics engine computing provider scorecards, rolling trend analysis, breakeven distance tracking, monthly aggregation, and a rules-based recommendations engine. Applies the same +216 Anne Jenks manual adjustment as the RVU charts.
- New /admin/reports/owner_analytics endpoint (Owner-only) returning all analytics as JSON.
- New "Owner Analytics" tab in admin dashboard (Owner-only) with Chart.js visualizations: rolling-4-week averages, WoW% company change, cumulative RVU race, breakeven distance bars, monthly stacked bars, and an inline recommendations panel. Data loads lazily on first tab click.