### PR TITLE
Fix quarterly bonus formula with correct three-tier RVU structure

### DIFF
--- a/data/quarterly_bonus_analytics.py
+++ b/data/quarterly_bonus_analytics.py
@@ -10,9 +10,39 @@ except ImportError:
 # ---------------------------------------------------------------------------
 VALID_PROVIDERS = ['ANNE JENKS', 'EHRIN IRVIN', 'HEATHER MAYO', 'SARAH SUGGS']
 
-BREAKEVEN_RVUS_PER_WEEK = 49    # individual weekly breakeven (matches chart reference line)
-BONUS_RATE_PER_RVU = 10.0       # $ bonus earned per RVU above quarterly threshold
 ANNE_JENKS_ADJUSTMENT = 216     # manual RVU credit added to Anne Jenks
+
+# Tiered bonus thresholds and rates
+BONUS_THRESHOLD = 689   # no bonus at or below this RVU total
+TIER1_CAP = 735         # Tier 1 ends here (inclusive)
+TIER2_CAP = 827         # Tier 2 ends here (inclusive)
+TIER1_RATE = 25.0       # $ per RVU above 689 (up to 735)
+TIER2_RATE = 30.0       # $ per RVU above 735 (up to 827)
+TIER3_RATE = 35.0       # $ per RVU above 827
+
+
+# ---------------------------------------------------------------------------
+# Bonus calculation
+# ---------------------------------------------------------------------------
+
+def calculate_tiered_bonus(total_rvus):
+    """Return the bonus earned for a given quarterly RVU total.
+
+    Tiers:
+        ≤689 RVUs        → $0
+        690–735 RVUs     → $25 per RVU above 689
+        736–827 RVUs     → $30 per RVU above 735, plus Tier 1 max ($1,150)
+        828+   RVUs      → $35 per RVU above 827, plus Tier 1+2 max ($3,910)
+    """
+    if total_rvus <= BONUS_THRESHOLD:
+        return 0.0
+    bonus = min(total_rvus, TIER1_CAP) - BONUS_THRESHOLD
+    bonus *= TIER1_RATE
+    if total_rvus > TIER1_CAP:
+        bonus += (min(total_rvus, TIER2_CAP) - TIER1_CAP) * TIER2_RATE
+    if total_rvus > TIER2_CAP:
+        bonus += (total_rvus - TIER2_CAP) * TIER3_RATE
+    return round(bonus, 2)
 
 
 # ---------------------------------------------------------------------------
@@ -80,9 +110,7 @@ def get_quarterly_bonus_report(year, quarter):
             ],
         }
 
-    Bonus formula:
-        threshold_rvus = (distinct weeks in quarter) * BREAKEVEN_RVUS_PER_WEEK
-        bonus_earned   = max(0, (total_rvus - threshold_rvus) * BONUS_RATE_PER_RVU)
+    Bonus formula: see calculate_tiered_bonus()
     """
     quarter_label = f'Q{quarter} {year}'
     df = rvu_analytics.get_rvu_dataset()
@@ -101,10 +129,6 @@ def get_quarterly_bonus_report(year, quarter):
     start, end = _quarter_date_range(year, quarter)
     quarter_df = df[(df['Date Of Service'] >= start) & (df['Date Of Service'] <= end)].copy()
 
-    # Count weeks that actually appear in that quarter's data for threshold calculation
-    num_weeks = int(quarter_df['Week'].nunique()) if not quarter_df.empty else 0
-    threshold_rvus = num_weeks * BREAKEVEN_RVUS_PER_WEEK
-
     # Aggregate RVUs per provider
     if not quarter_df.empty:
         provider_rvus = quarter_df.groupby('Provider')['RVU'].sum()
@@ -114,12 +138,11 @@ def get_quarterly_bonus_report(year, quarter):
     result_providers = []
     for p in VALID_PROVIDERS:
         total_rvus = float(provider_rvus.get(p, 0.0))
-        bonus = max(0.0, (total_rvus - threshold_rvus) * BONUS_RATE_PER_RVU)
         result_providers.append({
             'name': p.title(),
             'total_rvus': round(total_rvus, 1),
-            'threshold_rvus': threshold_rvus,
-            'bonus_earned': round(bonus, 2),
+            'threshold_rvus': BONUS_THRESHOLD,
+            'bonus_earned': calculate_tiered_bonus(total_rvus),
         })
 
     return {

--- a/data/tests/test_quarterly_bonus_analytics.py
+++ b/data/tests/test_quarterly_bonus_analytics.py
@@ -135,11 +135,11 @@ class TestQuarterlyBonusReport(unittest.TestCase):
 
     @patch('quarterly_bonus_analytics.rvu_analytics')
     def test_bonus_positive_above_threshold(self, mock_rvu):
-        # 1 week with 200 RVUs total → threshold = 1 * 49 = 49
+        # 10 rows × 80 RVUs = 800 total RVUs → Tier 2 bonus
         df = pd.DataFrame({
             'Date Of Service': pd.to_datetime(['2026-01-07'] * 10),
             'Provider': ['EHRIN IRVIN'] * 10,
-            'RVU': [20.0] * 10,
+            'RVU': [80.0] * 10,
             'Category': ['VA Exam'] * 10,
             'Week': pd.to_datetime(['2026-01-10'] * 10),
         })
@@ -149,12 +149,12 @@ class TestQuarterlyBonusReport(unittest.TestCase):
         providers = {p['name']: p for p in report['providers']}
         ehrin = providers['Ehrin Irvin']
         self.assertGreater(ehrin['bonus_earned'], 0.0)
-        expected_bonus = (200.0 - 49) * qba.BONUS_RATE_PER_RVU
-        self.assertAlmostEqual(ehrin['bonus_earned'], expected_bonus, delta=1.0)
+        # 800 RVUs: Tier 1 (690–735) = 46×$25=$1,150 + Tier 2 (736–800) = 65×$30=$1,950 = $3,100
+        self.assertAlmostEqual(ehrin['bonus_earned'], 3100.0, delta=1.0)
 
     @patch('quarterly_bonus_analytics.rvu_analytics')
-    def test_threshold_equals_weeks_times_breakeven(self, mock_rvu):
-        # Q1 2026 data spanning 3 distinct weeks
+    def test_threshold_rvus_is_fixed_base(self, mock_rvu):
+        # threshold_rvus should reflect the fixed base bonus threshold (689)
         df = pd.DataFrame({
             'Date Of Service': pd.to_datetime(['2026-01-07', '2026-01-14', '2026-01-21']),
             'Provider': ['EHRIN IRVIN', 'EHRIN IRVIN', 'EHRIN IRVIN'],
@@ -167,8 +167,7 @@ class TestQuarterlyBonusReport(unittest.TestCase):
 
         providers = {p['name']: p for p in report['providers']}
         ehrin = providers['Ehrin Irvin']
-        expected_threshold = 3 * qba.BREAKEVEN_RVUS_PER_WEEK
-        self.assertEqual(ehrin['threshold_rvus'], expected_threshold)
+        self.assertEqual(ehrin['threshold_rvus'], qba.BONUS_THRESHOLD)
 
     @patch('quarterly_bonus_analytics.rvu_analytics')
     def test_empty_dataset_returns_empty_report(self, mock_rvu):
@@ -204,6 +203,38 @@ class TestQuarterlyBonusReport(unittest.TestCase):
 
         self.assertIn('2025Q4', report['available_quarters'])
         self.assertIn('2026Q1', report['available_quarters'])
+
+
+class TestCalculateTieredBonus(unittest.TestCase):
+    """Unit tests for the tiered bonus formula, validated against spec examples."""
+
+    def _b(self, rvus):
+        return qba.calculate_tiered_bonus(rvus)
+
+    def test_at_threshold_no_bonus(self):
+        self.assertEqual(self._b(689), 0.0)
+
+    def test_below_threshold_no_bonus(self):
+        self.assertEqual(self._b(0), 0.0)
+        self.assertEqual(self._b(688), 0.0)
+
+    def test_tier1_first_rvu(self):
+        self.assertEqual(self._b(690), 25.0)
+
+    def test_tier1_max(self):
+        self.assertEqual(self._b(735), 1150.0)
+
+    def test_tier2_first_rvu(self):
+        self.assertEqual(self._b(736), 1180.0)
+
+    def test_tier2_max(self):
+        self.assertEqual(self._b(827), 3910.0)
+
+    def test_tier3_first_rvu(self):
+        self.assertEqual(self._b(828), 3945.0)
+
+    def test_tier3_extended(self):
+        self.assertEqual(self._b(900), 6465.0)
 
 
 if __name__ == '__main__':

--- a/tests/test_quarterly_bonus_route.py
+++ b/tests/test_quarterly_bonus_route.py
@@ -10,10 +10,14 @@ MOCK_REPORT = {
     'quarter_label': 'Q1 2026',
     'available_quarters': ['2026Q1', '2025Q4'],
     'providers': [
-        {'name': 'Anne Jenks',   'total_rvus': 850.0, 'threshold_rvus': 637, 'bonus_earned': 2130.0},
-        {'name': 'Ehrin Irvin',  'total_rvus': 500.0, 'threshold_rvus': 637, 'bonus_earned':    0.0},
-        {'name': 'Heather Mayo', 'total_rvus': 100.0, 'threshold_rvus': 637, 'bonus_earned':    0.0},
-        {'name': 'Sarah Suggs',  'total_rvus': 700.0, 'threshold_rvus': 637, 'bonus_earned':  630.0},
+        # 850 RVUs: Tier3 = $3,910 + $35*(850-827) = $3,910 + $805 = $4,715
+        {'name': 'Anne Jenks',   'total_rvus': 850.0, 'threshold_rvus': 689, 'bonus_earned': 4715.0},
+        # 500 RVUs: below threshold → $0
+        {'name': 'Ehrin Irvin',  'total_rvus': 500.0, 'threshold_rvus': 689, 'bonus_earned':    0.0},
+        # 100 RVUs: below threshold → $0
+        {'name': 'Heather Mayo', 'total_rvus': 100.0, 'threshold_rvus': 689, 'bonus_earned':    0.0},
+        # 700 RVUs: Tier1 = $25*(700-689) = $25*11 = $275
+        {'name': 'Sarah Suggs',  'total_rvus': 700.0, 'threshold_rvus': 689, 'bonus_earned':  275.0},
     ],
 }
 
@@ -134,8 +138,8 @@ class QuarterlyBonusRouteTestCase(unittest.TestCase):
             data=dict(action='generate_quarterly_bonus', quarter='2026Q1'),
             follow_redirects=True,
         )
-        self.assertIn(b'2130', response.data)   # Anne Jenks bonus
-        self.assertIn(b'630', response.data)    # Sarah Suggs bonus
+        self.assertIn(b'4715', response.data)   # Anne Jenks bonus
+        self.assertIn(b'275', response.data)    # Sarah Suggs bonus
 
     @patch('app.quarterly_bonus_analytics.get_quarterly_bonus_report', return_value=MOCK_REPORT)
     def test_quarter_selector_shows_available_quarters(self, _mock):


### PR DESCRIPTION
## Changes

- **Replaced linear bonus formula** with a three-tier RVU structure:
  - Tier 1 (690–735 RVUs): $25 per RVU
  - Tier 2 (736–827 RVUs): $30 per RVU
  - Tier 3 (828+ RVUs): $35 per RVU
  - No bonus for ≤689 RVUs

- **Implemented `calculate_tiered_bonus()` function** to compute bonuses based on the new tiered structure

- **Simplified threshold calculation**: Removed dynamic week-based threshold; now uses fixed `BONUS_THRESHOLD = 689`

- **Updated test suite**:
  - Added comprehensive unit tests for all three bonus tiers
  - Updated integration tests with correct bonus amounts
  - Fixed expected bonus values in route tests

- **Removed obsolete constants**: `BREAKEVEN_RVUS_PER_WEEK` and `BONUS_RATE_PER_RVU`