### PR TITLE
Time-varying RVU thresholds + Quarterly Bonus default quarter

### DIFF
--- a/.claude/settings.local.json
+++ b/.claude/settings.local.json
@@ -13,7 +13,13 @@
       "Bash(python -m pytest data/tests/test_quarterly_bonus_analytics.py tests/test_quarterly_bonus_route.py -v)",
       "Bash(python -m pytest data/tests -x -q)",
       "Bash(python3 -m pytest data/tests -x -q)",
-      "Bash(python3 -c \"import ast; [ast.parse\\(open\\(p\\).read\\(\\)\\) for p in ['data/tebra_sync.py','data/sync_manager.py','data/rvu_analytics.py','data/owner_analytics.py','init_db.py']]; print\\('OK'\\)\")"
+      "Bash(python3 -c \"import ast; [ast.parse\\(open\\(p\\).read\\(\\)\\) for p in ['data/tebra_sync.py','data/sync_manager.py','data/rvu_analytics.py','data/owner_analytics.py','init_db.py']]; print\\('OK'\\)\")",
+      "Bash(python3 -m pytest tests/test_data_sync.py -x -q)",
+      "Bash(python3 -m pytest tests/test_data_sync.py data/tests -x -q)",
+      "Bash(python3 -c \"import ast; [ast.parse\\(open\\(p\\).read\\(\\)\\) for p in ['data/rvu_analytics.py','data/owner_analytics.py']]; print\\('OK'\\)\")",
+      "Bash(python3 -m pytest tests/ data/tests/ -x -q)",
+      "Bash(python3 -m pytest tests/ data/tests/ --deselect tests/test_new_patient_redirect.py -q)",
+      "Bash(python3 -m pytest tests/test_data_sync.py tests/test_reports.py tests/test_data_integrity.py tests/test_auth_and_roles.py tests/test_rbac.py data/tests/ -q)"
     ]
   }
 }

--- a/app.py
+++ b/app.py
@@ -515,9 +515,19 @@ def create_app():
         except Exception:
             available_quarters = []
 
+        default_quarter = available_quarters[0] if available_quarters else ''
+        bonus_report = None
+        if default_quarter and not needs_password_change:
+            try:
+                year = int(default_quarter[:4])
+                quarter = int(default_quarter[5])
+                bonus_report = quarterly_bonus_analytics.get_quarterly_bonus_report(year, quarter)
+            except Exception as exc:
+                app.logger.warning("Default bonus report failed for %s: %s", default_quarter, exc)
+
         return render_template('admin/dashboard.html', page_title='Admin Dashboard', banner=banner,
                                needs_password_change=needs_password_change, appt_requests=appt_requests,
-                               bonus_report=None, selected_quarter='',
+                               bonus_report=bonus_report, selected_quarter=default_quarter,
                                available_quarters=available_quarters)
 
     @app.route('/admin/reports/rvu_image')

--- a/data/owner_analytics.py
+++ b/data/owner_analytics.py
@@ -3,6 +3,7 @@ Owner-only analytics for Jenks Family Medicine admin dashboard.
 Computes Provider Scorecards, Trend Analysis, Breakeven Analysis,
 Monthly Aggregation, and Recommendations Engine.
 """
+import numpy as np
 import pandas as pd
 from datetime import datetime, timedelta
 
@@ -18,10 +19,21 @@ PROVIDER_COLORS = {
     'Heather Mayo': '#f39c12',
     'Sarah Suggs': '#9b59b6',
 }
-BREAKEVEN_INDIVIDUAL = 37
-INDUSTRY_INDIVIDUAL = 70
-BREAKEVEN_COMPANY = 146
-INDUSTRY_COMPANY = 278
+
+
+def _threshold_arrays(weeks):
+    """Return per-week threshold arrays for the given weeks.
+
+    Weeks before PROVIDER_CUTOVER_WEEK use 4-provider thresholds;
+    weeks on/after use 3-provider thresholds.
+    """
+    post = pd.DatetimeIndex(weeks) >= rvu_analytics.PROVIDER_CUTOVER_WEEK
+    return {
+        'ind_breakeven': np.where(post, rvu_analytics.BREAKEVEN_INDIVIDUAL_POST, rvu_analytics.BREAKEVEN_INDIVIDUAL_PRE),
+        'ind_industry':  np.where(post, rvu_analytics.INDUSTRY_INDIVIDUAL_POST,  rvu_analytics.INDUSTRY_INDIVIDUAL_PRE),
+        'co_breakeven':  np.where(post, rvu_analytics.BREAKEVEN_COMPANY_POST,    rvu_analytics.BREAKEVEN_COMPANY_PRE),
+        'co_industry':   np.where(post, rvu_analytics.INDUSTRY_COMPANY_POST,     rvu_analytics.INDUSTRY_COMPANY_PRE),
+    }
 
 
 def _get_adjusted_df():
@@ -66,6 +78,9 @@ def get_scorecards():
     if df.empty:
         return {}
     prov_weekly, all_weeks = _weekly_by_provider(df)
+    thresholds = _threshold_arrays(all_weeks)
+    ind_be_arr = thresholds['ind_breakeven']
+    ind_ind_arr = thresholds['ind_industry']
     result = {}
     for p in PROVIDERS:
         arr = prov_weekly[p].values
@@ -80,8 +95,8 @@ def get_scorecards():
         result[display] = {
             'total_rvus': round(float(arr.sum()), 1),
             'avg_weekly': round(float(arr.mean()), 1),
-            'breakeven_hit_rate': round(float((arr >= BREAKEVEN_INDIVIDUAL).mean() * 100), 1),
-            'industry_hit_rate': round(float((arr >= INDUSTRY_INDIVIDUAL).mean() * 100), 1),
+            'breakeven_hit_rate': round(float((arr >= ind_be_arr).mean() * 100), 1),
+            'industry_hit_rate': round(float((arr >= ind_ind_arr).mean() * 100), 1),
             'best_week': round(float(arr.max()), 1),
             'worst_week': round(float(arr.min()), 1),
             'std_dev': round(float(arr.std(ddof=1)), 1) if n > 1 else 0.0,
@@ -113,6 +128,7 @@ def get_trends():
     company.index = pd.DatetimeIndex(company.index)
     company = company.reindex(pd.DatetimeIndex(all_weeks), fill_value=0.0)
     wow = company.pct_change().fillna(0).clip(-2, 2) * 100
+    thresholds = _threshold_arrays(all_weeks)
     return {
         'weeks': weeks_str,
         'providers': providers_out,
@@ -121,10 +137,10 @@ def get_trends():
             'wow_pct': [round(float(v), 1) for v in wow.values],
         },
         'benchmarks': {
-            'ind_breakeven': BREAKEVEN_INDIVIDUAL,
-            'ind_industry': INDUSTRY_INDIVIDUAL,
-            'co_breakeven': BREAKEVEN_COMPANY,
-            'co_industry': INDUSTRY_COMPANY,
+            'ind_breakeven': [int(v) for v in thresholds['ind_breakeven']],
+            'ind_industry':  [int(v) for v in thresholds['ind_industry']],
+            'co_breakeven':  [int(v) for v in thresholds['co_breakeven']],
+            'co_industry':   [int(v) for v in thresholds['co_industry']],
         },
     }
 
@@ -138,16 +154,20 @@ def get_breakeven_analysis():
     company = df.groupby('Week')['RVU'].sum()
     company.index = pd.DatetimeIndex(company.index)
     company = company.reindex(pd.DatetimeIndex(all_weeks), fill_value=0.0)
-    co_dist = [round(float(v - BREAKEVEN_COMPANY), 1) for v in company.values]
+    thresholds = _threshold_arrays(all_weeks)
+    co_be_arr = thresholds['co_breakeven']
+    ind_be_arr = thresholds['ind_breakeven']
+    ind_ind_arr = thresholds['ind_industry']
+    co_dist = [round(float(v - t), 1) for v, t in zip(company.values, co_be_arr)]
     providers_out = {}
     for p in PROVIDERS:
         arr = prov_weekly[p].values
         display = p.title()
-        dist = [round(float(v - BREAKEVEN_INDIVIDUAL), 1) for v in arr]
+        dist = [round(float(v - t), 1) for v, t in zip(arr, ind_be_arr)]
         providers_out[display] = {
             'distances': dist,
-            'hit_rate': round(float((arr >= BREAKEVEN_INDIVIDUAL).mean() * 100), 1),
-            'industry_hit_rate': round(float((arr >= INDUSTRY_INDIVIDUAL).mean() * 100), 1),
+            'hit_rate': round(float((arr >= ind_be_arr).mean() * 100), 1),
+            'industry_hit_rate': round(float((arr >= ind_ind_arr).mean() * 100), 1),
             'avg_weekly': round(float(arr.mean()), 1),
             'color': PROVIDER_COLORS.get(display, '#888'),
         }
@@ -166,7 +186,10 @@ def get_monthly():
     df['Month'] = pd.to_datetime(df['Week']).dt.to_period('M')
     all_months = sorted(df['Month'].unique())
     months_str = [m.strftime('%b %Y') for m in all_months]
-    weeks_per_month = {m: int(df[df['Month'] == m]['Week'].nunique()) for m in all_months}
+    month_weeks = {
+        m: sorted(pd.DatetimeIndex(df[df['Month'] == m]['Week'].unique()))
+        for m in all_months
+    }
     company = df.groupby('Month')['RVU'].sum().reindex(all_months, fill_value=0.0)
     providers_out = {}
     for p in PROVIDERS:
@@ -176,12 +199,26 @@ def get_monthly():
             'values': [round(float(v), 1) for v in s.values],
             'color': PROVIDER_COLORS.get(display, '#888'),
         }
+
+    def _sum_monthly(pre_value, post_value):
+        totals = []
+        for m in all_months:
+            weeks_in_month = month_weeks.get(m, [])
+            if not weeks_in_month:
+                totals.append(4 * post_value)
+                continue
+            totals.append(sum(
+                post_value if w >= rvu_analytics.PROVIDER_CUTOVER_WEEK else pre_value
+                for w in weeks_in_month
+            ))
+        return totals
+
     return {
         'months': months_str,
         'providers': providers_out,
         'company_total': [round(float(v), 1) for v in company.values],
-        'company_breakeven': [weeks_per_month.get(m, 4) * BREAKEVEN_COMPANY for m in all_months],
-        'company_industry': [weeks_per_month.get(m, 4) * INDUSTRY_COMPANY for m in all_months],
+        'company_breakeven': _sum_monthly(rvu_analytics.BREAKEVEN_COMPANY_PRE, rvu_analytics.BREAKEVEN_COMPANY_POST),
+        'company_industry':  _sum_monthly(rvu_analytics.INDUSTRY_COMPANY_PRE,  rvu_analytics.INDUSTRY_COMPANY_POST),
     }
 
 
@@ -197,14 +234,19 @@ def get_recommendations():
     insights = []
     co_avg = float(company.mean())
 
+    # Use current (post-cutover) thresholds for go-forward recommendations.
+    co_breakeven_current = rvu_analytics.BREAKEVEN_COMPANY_POST
+    ind_breakeven_current = rvu_analytics.BREAKEVEN_INDIVIDUAL_POST
+    ind_industry_current = rvu_analytics.INDUSTRY_INDIVIDUAL_POST
+
     # Company status
-    if co_avg >= BREAKEVEN_COMPANY:
+    if co_avg >= co_breakeven_current:
         insights.append({'type': 'success',
-                         'text': f"Company-wide production is on target at {co_avg:.1f} avg RVUs/week (breakeven: {BREAKEVEN_COMPANY})."})
+                         'text': f"Company-wide production is on target at {co_avg:.1f} avg RVUs/week (breakeven: {co_breakeven_current})."})
     else:
-        gap = BREAKEVEN_COMPANY - co_avg
+        gap = co_breakeven_current - co_avg
         insights.append({'type': 'warning',
-                         'text': f"Company-wide average of {co_avg:.1f} RVUs/week is {gap:.1f} below the {BREAKEVEN_COMPANY} breakeven target."})
+                         'text': f"Company-wide average of {co_avg:.1f} RVUs/week is {gap:.1f} below the {co_breakeven_current} breakeven target."})
 
     prov_avgs = {}
     for p in PROVIDERS:
@@ -214,13 +256,13 @@ def get_recommendations():
         avg = float(arr.mean())
         prov_avgs[display] = avg
 
-        if avg < BREAKEVEN_INDIVIDUAL:
-            gap = BREAKEVEN_INDIVIDUAL - avg
+        if avg < ind_breakeven_current:
+            gap = ind_breakeven_current - avg
             insights.append({'type': 'alert',
-                             'text': f"{display} is averaging {avg:.1f} RVUs/week — {gap:.1f} below the individual breakeven ({BREAKEVEN_INDIVIDUAL})."})
-        elif avg >= INDUSTRY_INDIVIDUAL:
+                             'text': f"{display} is averaging {avg:.1f} RVUs/week — {gap:.1f} below the individual breakeven ({ind_breakeven_current})."})
+        elif avg >= ind_industry_current:
             insights.append({'type': 'success',
-                             'text': f"{display} is at or above the industry standard ({INDUSTRY_INDIVIDUAL} RVUs/week), averaging {avg:.1f}."})
+                             'text': f"{display} is at or above the industry standard ({ind_industry_current} RVUs/week), averaging {avg:.1f}."})
 
         if n >= 8:
             recent = float(arr[-4:].mean())

--- a/data/quarterly_bonus_analytics.py
+++ b/data/quarterly_bonus_analytics.py
@@ -1,10 +1,20 @@
 import math
+from datetime import date as _date
+
 import pandas as pd
 
 try:
     from . import rvu_analytics
 except ImportError:
     import rvu_analytics
+
+
+def _current_quarter_label(today=None):
+    """Return current quarter label like '2026Q2'."""
+    if today is None:
+        today = _date.today()
+    quarter = (today.month - 1) // 3 + 1
+    return f'{today.year}Q{quarter}'
 
 # ---------------------------------------------------------------------------
 # Bonus configuration
@@ -81,15 +91,22 @@ def _quarter_date_range(year, quarter):
 # ---------------------------------------------------------------------------
 
 def get_available_quarters(df=None):
-    """Return quarter labels (e.g. '2026Q1') present in the dataset, newest first."""
+    """Return quarter labels (e.g. '2026Q1') present in the dataset, newest first.
+    The current quarter is always included at the top, even with no data yet,
+    so the admin dropdown is never empty mid-quarter."""
     if df is None:
         df = rvu_analytics.get_rvu_dataset()
-    if df is None or df.empty:
-        return []
-    df = df.copy()
-    df['Quarter'] = df['Date Of Service'].dt.to_period('Q')
-    quarters = sorted(df['Quarter'].dropna().unique(), reverse=True)
-    return [str(q) for q in quarters]
+
+    quarters = []
+    if df is not None and not df.empty:
+        df = df.copy()
+        df['Quarter'] = df['Date Of Service'].dt.to_period('Q')
+        quarters = [str(q) for q in sorted(df['Quarter'].dropna().unique(), reverse=True)]
+
+    current = _current_quarter_label()
+    if current not in quarters:
+        quarters = [current] + quarters
+    return quarters
 
 
 def get_quarterly_bonus_report(year, quarter):

--- a/data/rvu_analytics.py
+++ b/data/rvu_analytics.py
@@ -12,6 +12,29 @@ try:
 except ImportError:
     import data_loader
 
+# Provider-count cutover. Week ending 2026-04-24 and later runs with 3
+# providers; earlier weeks ran with 4. Thresholds before/after reflect that.
+PROVIDER_CUTOVER_WEEK = pd.Timestamp('2026-04-24')
+
+BREAKEVEN_COMPANY_PRE = 196
+INDUSTRY_COMPANY_PRE = 328
+BREAKEVEN_INDIVIDUAL_PRE = 49   # 196 / 4
+INDUSTRY_INDIVIDUAL_PRE = 82    # 328 / 4
+
+BREAKEVEN_COMPANY_POST = 146
+INDUSTRY_COMPANY_POST = 278
+BREAKEVEN_INDIVIDUAL_POST = 49  # round(146 / 3)
+INDUSTRY_INDIVIDUAL_POST = 93   # round(278 / 3)
+
+
+def _threshold_series(weeks, pre_value, post_value):
+    """Return per-week threshold values, pre-cutover on earlier weeks."""
+    return [
+        pre_value if pd.Timestamp(w) < PROVIDER_CUTOVER_WEEK else post_value
+        for w in weeks
+    ]
+
+
 def _get_clinical_rvu_val(row):
     _svc_raw = row.get('Procedure Codes with Modifiers', row.get('Procedure Code'))
     # row.get() can return a Series if the DataFrame has duplicate column names;
@@ -251,8 +274,12 @@ def generate_rvu_chart(view_type, data_source='all', include_pipeline=False, exc
             ax.plot(pipe_x, weekly_combined.astype(float).tolist(), marker='o', color='#37a4db',
                     linewidth=1.5, markersize=6, linestyle='--', alpha=0.55, label='Pipeline (draft charges)')
 
-        ax.axhline(y=146, color='red', linestyle='--', linewidth=2, label='Company Breakeven (146)')
-        ax.axhline(y=278, color='orange', linestyle='--', linewidth=2, label='Industry Standard (278)')
+        be_vals = _threshold_series(weekly['Week'], BREAKEVEN_COMPANY_PRE, BREAKEVEN_COMPANY_POST)
+        tg_vals = _threshold_series(weekly['Week'], INDUSTRY_COMPANY_PRE, INDUSTRY_COMPANY_POST)
+        ax.plot(x_labels, be_vals, color='red', linestyle='--', linewidth=2,
+                label='Company Breakeven', drawstyle='steps-post')
+        ax.plot(x_labels, tg_vals, color='orange', linestyle='--', linewidth=2,
+                label='Industry Standard', drawstyle='steps-post')
         ax.set_title('Company-Wide Weekly RVUs', fontsize=14, fontweight='bold')
 
     elif view_type == 'Provider Comparison':
@@ -279,8 +306,12 @@ def generate_rvu_chart(view_type, data_source='all', include_pipeline=False, exc
                 ax.plot(pipe_x, combined.astype(float).tolist(), marker='o', linewidth=1.5, markersize=5,
                         linestyle='--', alpha=0.55, color=color, label=pipe_label)
 
-        ax.axhline(y=37, color='red', linestyle='--', linewidth=2, label='Individual Breakeven (37)')
-        ax.axhline(y=70, color='orange', linestyle='--', linewidth=2, label='Industry Standard (70)')
+        be_vals = _threshold_series(pivot_df.index, BREAKEVEN_INDIVIDUAL_PRE, BREAKEVEN_INDIVIDUAL_POST)
+        tg_vals = _threshold_series(pivot_df.index, INDUSTRY_INDIVIDUAL_PRE, INDUSTRY_INDIVIDUAL_POST)
+        ax.plot(x_labels, be_vals, color='red', linestyle='--', linewidth=2,
+                label='Individual Breakeven', drawstyle='steps-post')
+        ax.plot(x_labels, tg_vals, color='orange', linestyle='--', linewidth=2,
+                label='Industry Standard', drawstyle='steps-post')
         ax.set_title('Provider Weekly RVU Comparison', fontsize=14, fontweight='bold')
 
     elif view_type in [p.title() for p in valid_providers] or view_type.upper() in valid_providers:
@@ -306,8 +337,12 @@ def generate_rvu_chart(view_type, data_source='all', include_pipeline=False, exc
                 ax.plot(pipe_x, combined.astype(float).tolist(), marker='o', color='#2ecc71',
                         linewidth=1.5, markersize=6, linestyle='--', alpha=0.55, label='Pipeline (draft charges)')
 
-        ax.axhline(y=37, color='red', linestyle='--', linewidth=2, label='Individual Breakeven (37)')
-        ax.axhline(y=70, color='orange', linestyle='--', linewidth=2, label='Industry Standard (70)')
+        be_vals = _threshold_series(prov_data['Week'], BREAKEVEN_INDIVIDUAL_PRE, BREAKEVEN_INDIVIDUAL_POST)
+        tg_vals = _threshold_series(prov_data['Week'], INDUSTRY_INDIVIDUAL_PRE, INDUSTRY_INDIVIDUAL_POST)
+        ax.plot(x_labels, be_vals, color='red', linestyle='--', linewidth=2,
+                label='Individual Breakeven', drawstyle='steps-post')
+        ax.plot(x_labels, tg_vals, color='orange', linestyle='--', linewidth=2,
+                label='Industry Standard', drawstyle='steps-post')
         ax.set_title(f'{display_name} - Weekly RVUs', fontsize=14, fontweight='bold')
 
     else:

--- a/data/tests/test_quarterly_bonus_analytics.py
+++ b/data/tests/test_quarterly_bonus_analytics.py
@@ -42,16 +42,15 @@ class TestGetAvailableQuarters(unittest.TestCase):
         self.assertIn('2025Q4', quarters)
         self.assertIn('2026Q1', quarters)
 
-    def test_returns_empty_for_empty_dataframe(self):
+    def test_empty_dataframe_still_includes_current_quarter(self):
         quarters = qba.get_available_quarters(pd.DataFrame())
-        self.assertEqual(quarters, [])
+        self.assertEqual(quarters, [qba._current_quarter_label()])
 
     def test_quarters_sorted_descending(self):
         df = _make_multi_quarter_df()
         quarters = qba.get_available_quarters(df)
-        # Most recent quarter first
-        self.assertEqual(quarters.index('2026Q1'), 0)
-        self.assertEqual(quarters.index('2025Q4'), 1)
+        # Historical quarters appear newest-first (current quarter is prepended).
+        self.assertLess(quarters.index('2026Q1'), quarters.index('2025Q4'))
 
 
 class TestQuarterlyBonusReport(unittest.TestCase):
@@ -216,7 +215,8 @@ class TestQuarterlyBonusReport(unittest.TestCase):
         report = qba.get_quarterly_bonus_report(2026, 1)
 
         self.assertEqual(report['providers'], [])
-        self.assertEqual(report['available_quarters'], [])
+        # Current quarter is always present even without data
+        self.assertEqual(report['available_quarters'], [qba._current_quarter_label()])
         self.assertEqual(report['quarter_label'], 'Q1 2026')
 
     @patch('quarterly_bonus_analytics.rvu_analytics')

--- a/templates/admin/dashboard.html
+++ b/templates/admin/dashboard.html
@@ -410,7 +410,7 @@
                 <p style="color: var(--text-light); font-size: 0.95rem; margin-bottom: 1.5rem;">
                     Select a historical quarter to see total RVUs earned and bonus earned per provider.<br>
                     <small>Bonus = max(0, (Total RVUs &minus; Threshold RVUs) &times; ${{ '%.0f'|format(10) }}/RVU) &nbsp;&bull;&nbsp;
-                    Threshold = weeks in quarter &times; 37 RVUs/week (individual breakeven)</small>
+                    Threshold = weeks in quarter &times; 49 RVUs/week (individual breakeven)</small>
                 </p>
 
                 <form method="POST" action="{{ url_for('admin_dashboard') }}" style="margin-bottom: 2rem;">
@@ -691,7 +691,7 @@
                 <!-- 3. Breakeven Analysis -->
                 <div id="oa-breakeven" class="admin-panel">
                     <h2>&#x1F3AF; Breakeven Analysis</h2>
-                    <p style="font-weight: 600; font-size: 0.85rem; color: var(--text-light); margin-bottom: 0.5rem; text-transform: uppercase; letter-spacing: 0.04em;">Company-Wide Distance from Breakeven (146 RVUs/week)</p>
+                    <p style="font-weight: 600; font-size: 0.85rem; color: var(--text-light); margin-bottom: 0.5rem; text-transform: uppercase; letter-spacing: 0.04em;">Company-Wide Distance from Weekly Breakeven (196 pre-4/24, 146 after)</p>
                     <div style="position: relative; height: 260px;">
                         <canvas id="chart-co-breakeven"></canvas>
                     </div>
@@ -1432,8 +1432,8 @@
             // Rolling 4-week average
             _destroyChart('chart-rolling4');
             const benchDatasets = [
-                { label: 'Breakeven (37)', data: weeks.map(() => b.ind_breakeven), borderColor: '#ef4444', borderDash: [6, 3], borderWidth: 1.5, pointRadius: 0, fill: false },
-                { label: 'Industry (70)', data: weeks.map(() => b.ind_industry), borderColor: '#f97316', borderDash: [6, 3], borderWidth: 1.5, pointRadius: 0, fill: false }
+                { label: 'Breakeven', data: b.ind_breakeven, stepped: 'after', borderColor: '#ef4444', borderDash: [6, 3], borderWidth: 1.5, pointRadius: 0, fill: false },
+                { label: 'Industry', data: b.ind_industry, stepped: 'after', borderColor: '#f97316', borderDash: [6, 3], borderWidth: 1.5, pointRadius: 0, fill: false }
             ];
             _chartInstances['chart-rolling4'] = new Chart(
                 document.getElementById('chart-rolling4').getContext('2d'),
@@ -1499,7 +1499,7 @@
                     data: {
                         labels: weeks,
                         datasets: [{
-                            label: 'RVUs vs Breakeven (146)',
+                            label: 'RVUs vs Weekly Breakeven',
                             data: dists,
                             backgroundColor: dists.map(v => v >= 0 ? '#27ae6088' : '#e74c3c88'),
                             borderColor: dists.map(v => v >= 0 ? '#27ae60' : '#e74c3c'),
@@ -1524,7 +1524,7 @@
                     </td>
                     <td style="padding:0.5rem 0.75rem;text-align:center;font-weight:600;">${d.avg_weekly}</td>
                     <td style="padding:0.5rem 0.75rem;text-align:center;">
-                        <span style="color:${d.avg_weekly >= 37 ? '#166534' : '#991b1b'};font-weight:600;">${d.hit_rate}%</span>
+                        <span style="color:${d.avg_weekly >= 49 ? '#166534' : '#991b1b'};font-weight:600;">${d.hit_rate}%</span>
                     </td>
                     <td style="padding:0.5rem 0.75rem;text-align:center;">
                         <span style="color:${d.industry_hit_rate >= 50 ? '#166534' : '#991b1b'};font-weight:600;">${d.industry_hit_rate}%</span>
@@ -1536,8 +1536,8 @@
                         <tr style="border-bottom:2px solid #e5e7eb;">
                             <th style="padding:0.5rem 0.75rem;text-align:left;font-size:0.75rem;color:#6b7280;text-transform:uppercase;letter-spacing:0.05em;">Provider</th>
                             <th style="padding:0.5rem 0.75rem;text-align:center;font-size:0.75rem;color:#6b7280;text-transform:uppercase;letter-spacing:0.05em;">Avg/Week</th>
-                            <th style="padding:0.5rem 0.75rem;text-align:center;font-size:0.75rem;color:#6b7280;text-transform:uppercase;letter-spacing:0.05em;">Breakeven Rate (&ge;37)</th>
-                            <th style="padding:0.5rem 0.75rem;text-align:center;font-size:0.75rem;color:#6b7280;text-transform:uppercase;letter-spacing:0.05em;">Industry Rate (&ge;70)</th>
+                            <th style="padding:0.5rem 0.75rem;text-align:center;font-size:0.75rem;color:#6b7280;text-transform:uppercase;letter-spacing:0.05em;">Breakeven Rate</th>
+                            <th style="padding:0.5rem 0.75rem;text-align:center;font-size:0.75rem;color:#6b7280;text-transform:uppercase;letter-spacing:0.05em;">Industry Rate</th>
                         </tr>
                     </thead>
                     <tbody>${rows}</tbody>

--- a/tests/test_data_sync.py
+++ b/tests/test_data_sync.py
@@ -197,6 +197,48 @@ def test_merge_charges_existing_data_deduped_internally():
     assert epids.count("epid_001") == 1
 
 
+def test_merge_charges_120_day_overlap_no_duplicates():
+    """Simulates the incremental sync overlap: re-pulling the same 120-day
+    window on every run must not inflate totals."""
+    from data.sync_manager import _merge_charges
+    existing = _charges_df([f"epid_{i:04d}" for i in range(100)])
+    # Re-pull the full 100 + 5 genuinely new (mimics overlap behavior)
+    overlap_pull = _charges_df([f"epid_{i:04d}" for i in range(105)])
+    merged, new_count = _merge_charges(existing, overlap_pull)
+    assert new_count == 5
+    assert len(merged) == 105
+    epids = merged["Encounter Procedure ID"].tolist()
+    assert len(epids) == len(set(epids)), "overlap re-pull produced duplicates"
+
+
+def test_fetch_charges_incremental_extends_window_for_draft_promotions():
+    """The incremental window must reach back at least 120 days so drafts
+    approved after the previous sync are captured."""
+    from datetime import date, timedelta
+    from unittest.mock import patch
+    from data.tebra_sync import fetch_charges_incremental, DRAFT_PROMOTION_LOOKBACK_DAYS
+
+    today = date.today()
+    # Simulate last sync 10 days ago — a draft with service date 60 days ago
+    # approved yesterday would otherwise be missed.
+    last_sync = today - timedelta(days=10)
+
+    captured = {}
+    def fake_fetch(start, end):
+        captured["start"] = start
+        captured["end"] = end
+        return pd.DataFrame(columns=["Encounter Procedure ID"])
+
+    with patch("data.tebra_sync.fetch_charges", side_effect=fake_fetch):
+        fetch_charges_incremental(last_sync_date=last_sync)
+
+    expected_start = today - timedelta(days=DRAFT_PROMOTION_LOOKBACK_DAYS)
+    assert captured["start"] == expected_start, (
+        f"Overlap window must start {DRAFT_PROMOTION_LOOKBACK_DAYS} days back, "
+        f"got {captured['start']}"
+    )
+
+
 # ---------------------------------------------------------------------------
 # Sync manager — _merge_201s
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Time-varying RVU thresholds at the 2026-04-24 provider cutover (4 to 3 providers): chart reference lines step down from 196/328 to 146/278 on that week; individual thresholds recompute as company / providers.
- Owner-analytics trends, breakeven distances, monthly totals, and scorecard hit rates all honor per-week thresholds.
- Quarterly Bonus Report: dropdown always includes the current quarter, defaults the selection to it, and auto-renders the current quarters report on initial GET (no more empty dropdown, no missing report).

## Test plan
- [x] 82 unit tests pass including new overlap-dedup tests and updated quarterly-bonus tests.
- [x] RVU chart renders cleanly for Company Wide, Provider Comparison, and Individual views across the cutover.
- [x] Per-week threshold arrays verified: April 2026 monthly breakeven = 3x196 + 1x146 = 734.

Co-authored by Claude Code.